### PR TITLE
Draft idea of TracingJedisPool

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,23 @@ String value = jc.get("foo");
 
 ```
 
+### Jedis Pool
+```java
+// Configure the pool
+JedisPoolConfig poolConfig = new JedisPoolConfig();
+poolConfig.setMaxIdle(10);
+poolConfig.setTestOnBorrow(false);
+
+// Create Tracing Jedis Pool
+JedisPool pool = new TracingJedisPool(poolConfig, "127.0.0.1", 6379, tracer, false);
+
+try (Jedis jedis = pool.getResource()) {
+    // jedis will be automatically closed and returned to the pool at the end of "try" block
+    jedis.set("foo", "bar");
+    String value = jedis.get("foo");
+}
+```
+
 ### Lettuce
 
 ```java

--- a/opentracing-redis-jedis/src/main/java/io/opentracing/contrib/redis/jedis/TracingJedisPool.java
+++ b/opentracing-redis-jedis/src/main/java/io/opentracing/contrib/redis/jedis/TracingJedisPool.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.redis.jedis;
 
 import io.opentracing.Tracer;

--- a/opentracing-redis-jedis/src/main/java/io/opentracing/contrib/redis/jedis/TracingJedisPool.java
+++ b/opentracing-redis-jedis/src/main/java/io/opentracing/contrib/redis/jedis/TracingJedisPool.java
@@ -1,0 +1,321 @@
+package io.opentracing.contrib.redis.jedis;
+
+import io.opentracing.Tracer;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocketFactory;
+import java.net.URI;
+
+public class TracingJedisPool extends JedisPool {
+  private final Tracer tracer;
+  private final boolean traceWithActiveSpanOnly;
+
+
+  public TracingJedisPool(Tracer tracer, boolean traceWithActiveSpanOnly) {
+    super();
+    this.tracer = tracer;
+    this.traceWithActiveSpanOnly = traceWithActiveSpanOnly;
+  }
+
+  public TracingJedisPool(final GenericObjectPoolConfig poolConfig, final String host,
+                          Tracer tracer, boolean traceWithActiveSpanOnly) {
+    super(poolConfig, host);
+    this.tracer = tracer;
+    this.traceWithActiveSpanOnly = traceWithActiveSpanOnly;
+  }
+
+  public TracingJedisPool(final String host, final int port, Tracer tracer, boolean traceWithActiveSpanOnly) {
+    super(host, port);
+    this.tracer = tracer;
+    this.traceWithActiveSpanOnly = traceWithActiveSpanOnly;
+
+  }
+
+  public TracingJedisPool(final String host, Tracer tracer, boolean traceWithActiveSpanOnly) {
+    super(host);
+    this.tracer = tracer;
+    this.traceWithActiveSpanOnly = traceWithActiveSpanOnly;
+
+  }
+
+  public TracingJedisPool(final String host, final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
+                          final HostnameVerifier hostnameVerifier, Tracer tracer, boolean traceWithActiveSpanOnly) {
+    super(host, sslSocketFactory, sslParameters, hostnameVerifier);
+    this.tracer = tracer;
+    this.traceWithActiveSpanOnly = traceWithActiveSpanOnly;
+  }
+
+  public TracingJedisPool(final URI uri, Tracer tracer, boolean traceWithActiveSpanOnly) {
+    super(uri);
+    this.tracer = tracer;
+    this.traceWithActiveSpanOnly = traceWithActiveSpanOnly;
+  }
+
+  public TracingJedisPool(final URI uri, final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
+                          final HostnameVerifier hostnameVerifier, Tracer tracer, boolean traceWithActiveSpanOnly) {
+    super(uri, sslSocketFactory, sslParameters, hostnameVerifier);
+    this.tracer = tracer;
+    this.traceWithActiveSpanOnly = traceWithActiveSpanOnly;
+  }
+
+  public TracingJedisPool(final URI uri, final int timeout, Tracer tracer, boolean traceWithActiveSpanOnly) {
+    super(uri, timeout);
+    this.tracer = tracer;
+    this.traceWithActiveSpanOnly = traceWithActiveSpanOnly;
+  }
+
+  public TracingJedisPool(final URI uri, final int timeout, final SSLSocketFactory sslSocketFactory,
+                          final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier,
+                          Tracer tracer, boolean traceWithActiveSpanOnly) {
+    super(uri, timeout, sslSocketFactory, sslParameters, hostnameVerifier);
+    this.tracer = tracer;
+    this.traceWithActiveSpanOnly = traceWithActiveSpanOnly;
+  }
+
+  public TracingJedisPool(final GenericObjectPoolConfig poolConfig, final String host, final int port,
+                          final int timeout, final String password,
+                          Tracer tracer, boolean traceWithActiveSpanOnly) {
+    super(poolConfig, host, port, timeout, password);
+    this.tracer = tracer;
+    this.traceWithActiveSpanOnly = traceWithActiveSpanOnly;
+  }
+
+  public TracingJedisPool(final GenericObjectPoolConfig poolConfig, final String host, final int port,
+                          final int timeout, final String password, final boolean ssl,
+                          Tracer tracer, boolean traceWithActiveSpanOnly) {
+    super(poolConfig, host, port, timeout, password, ssl);
+    this.tracer = tracer;
+    this.traceWithActiveSpanOnly = traceWithActiveSpanOnly;
+  }
+
+  public TracingJedisPool(final GenericObjectPoolConfig poolConfig, final String host, final int port,
+                          final int timeout, final String password, final boolean ssl,
+                          final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
+                          final HostnameVerifier hostnameVerifier, Tracer tracer, boolean traceWithActiveSpanOnly) {
+    super(poolConfig, host, port, timeout, password, ssl, sslSocketFactory, sslParameters, hostnameVerifier);
+    this.tracer = tracer;
+    this.traceWithActiveSpanOnly = traceWithActiveSpanOnly;
+  }
+
+  public TracingJedisPool(final GenericObjectPoolConfig poolConfig, final String host, final int port,
+                          Tracer tracer, boolean traceWithActiveSpanOnly) {
+    super(poolConfig, host, port);
+    this.tracer = tracer;
+    this.traceWithActiveSpanOnly = traceWithActiveSpanOnly;
+  }
+
+  public TracingJedisPool(final GenericObjectPoolConfig poolConfig, final String host, final int port, final boolean ssl,
+                          Tracer tracer, boolean traceWithActiveSpanOnly) {
+    super(poolConfig, host, port, ssl);
+    this.tracer = tracer;
+    this.traceWithActiveSpanOnly = traceWithActiveSpanOnly;
+  }
+
+  public TracingJedisPool(final GenericObjectPoolConfig poolConfig, final String host, final int port, final boolean ssl,
+                          final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
+                          final HostnameVerifier hostnameVerifier, Tracer tracer, boolean traceWithActiveSpanOnly) {
+    super(poolConfig, host, port, ssl, sslSocketFactory, sslParameters, hostnameVerifier);
+    this.tracer = tracer;
+    this.traceWithActiveSpanOnly = traceWithActiveSpanOnly;
+  }
+
+  public TracingJedisPool(final GenericObjectPoolConfig poolConfig, final String host, final int port, final int timeout,
+                          Tracer tracer, boolean traceWithActiveSpanOnly) {
+    super(poolConfig, host, port, timeout);
+    this.tracer = tracer;
+    this.traceWithActiveSpanOnly = traceWithActiveSpanOnly;
+  }
+
+  public TracingJedisPool(final GenericObjectPoolConfig poolConfig, final String host, final int port, final int timeout,
+                          final boolean ssl, Tracer tracer, boolean traceWithActiveSpanOnly) {
+    super(poolConfig, host, port, timeout, ssl);
+    this.tracer = tracer;
+    this.traceWithActiveSpanOnly = traceWithActiveSpanOnly;
+  }
+
+  public TracingJedisPool(final GenericObjectPoolConfig poolConfig, final String host, final int port, final int timeout,
+                          final boolean ssl, final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
+                          final HostnameVerifier hostnameVerifier, Tracer tracer, boolean traceWithActiveSpanOnly) {
+    super(poolConfig, host, port, timeout, ssl, sslSocketFactory, sslParameters, hostnameVerifier);
+    this.tracer = tracer;
+    this.traceWithActiveSpanOnly = traceWithActiveSpanOnly;
+  }
+
+  public TracingJedisPool(final GenericObjectPoolConfig poolConfig, final String host, final int port, final int timeout,
+                          final String password, final int database, Tracer tracer, boolean traceWithActiveSpanOnly) {
+    super(poolConfig, host, port, timeout, password, database);
+    this.tracer = tracer;
+    this.traceWithActiveSpanOnly = traceWithActiveSpanOnly;
+  }
+
+  public TracingJedisPool(final GenericObjectPoolConfig poolConfig, final String host, final int port, final int timeout,
+                          final String password, final int database, final boolean ssl,
+                          Tracer tracer, boolean traceWithActiveSpanOnly) {
+    super(poolConfig, host, port, timeout, password, database, ssl);
+    this.tracer = tracer;
+    this.traceWithActiveSpanOnly = traceWithActiveSpanOnly;
+  }
+
+  public TracingJedisPool(final GenericObjectPoolConfig poolConfig, final String host, final int port, final int timeout,
+                          final String password, final int database, final boolean ssl,
+                          final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
+                          final HostnameVerifier hostnameVerifier, Tracer tracer, boolean traceWithActiveSpanOnly) {
+    super(poolConfig, host, port, timeout, password, database, ssl, sslSocketFactory, sslParameters, hostnameVerifier);
+    this.tracer = tracer;
+    this.traceWithActiveSpanOnly = traceWithActiveSpanOnly;
+  }
+
+  public TracingJedisPool(final GenericObjectPoolConfig poolConfig, final String host, final int port, final int timeout,
+                          final String password, final int database, final String clientName,
+                          Tracer tracer, boolean traceWithActiveSpanOnly) {
+    this(poolConfig, host, port, timeout, timeout, password, database, clientName, false,
+        null, null, null, tracer, traceWithActiveSpanOnly);
+  }
+
+  public TracingJedisPool(final GenericObjectPoolConfig poolConfig, final String host, final int port, final int timeout,
+                          final String password, final int database, final String clientName, final boolean ssl,
+                          Tracer tracer, boolean traceWithActiveSpanOnly) {
+    super(poolConfig, host, port, timeout, password, database, clientName, ssl);
+    this.tracer = tracer;
+    this.traceWithActiveSpanOnly = traceWithActiveSpanOnly;
+  }
+
+  public TracingJedisPool(final GenericObjectPoolConfig poolConfig, final String host, final int port, final int timeout,
+                          final String password, final int database, final String clientName, final boolean ssl,
+                          final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
+                          final HostnameVerifier hostnameVerifier, Tracer tracer, boolean traceWithActiveSpanOnly) {
+    super(poolConfig, host, port, timeout, password, database, clientName, ssl, sslSocketFactory, sslParameters, hostnameVerifier);
+    this.tracer = tracer;
+    this.traceWithActiveSpanOnly = traceWithActiveSpanOnly;
+  }
+
+  public TracingJedisPool(final GenericObjectPoolConfig poolConfig, final String host, final int port,
+                          final int connectionTimeout, final int soTimeout, final String password, final int database,
+                          final String clientName, final boolean ssl, final SSLSocketFactory sslSocketFactory,
+                          final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier,
+                          Tracer tracer, boolean traceWithActiveSpanOnly) {
+
+    super(poolConfig, host, port, connectionTimeout, soTimeout, password, database, clientName, ssl,
+        sslSocketFactory, sslParameters, hostnameVerifier);
+    this.tracer = tracer;
+    this.traceWithActiveSpanOnly = traceWithActiveSpanOnly;
+  }
+
+  public TracingJedisPool(final GenericObjectPoolConfig poolConfig, final URI uri,
+                          Tracer tracer, boolean traceWithActiveSpanOnly) {
+    super(poolConfig, uri);
+    this.tracer = tracer;
+    this.traceWithActiveSpanOnly = traceWithActiveSpanOnly;
+
+  }
+
+  public TracingJedisPool(final GenericObjectPoolConfig poolConfig, final URI uri, final SSLSocketFactory sslSocketFactory,
+                          final SSLParameters sslParameters, final HostnameVerifier hostnameVerifier,
+                          Tracer tracer, boolean traceWithActiveSpanOnly) {
+    super(poolConfig, uri, sslSocketFactory, sslParameters, hostnameVerifier);
+    this.tracer = tracer;
+    this.traceWithActiveSpanOnly = traceWithActiveSpanOnly;
+
+  }
+
+  public TracingJedisPool(final GenericObjectPoolConfig poolConfig, final URI uri, final int timeout,
+                          Tracer tracer, boolean traceWithActiveSpanOnly) {
+    super(poolConfig, uri, timeout);
+    this.tracer = tracer;
+    this.traceWithActiveSpanOnly = traceWithActiveSpanOnly;
+  }
+
+  public TracingJedisPool(final GenericObjectPoolConfig poolConfig, final URI uri, final int timeout,
+                          final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
+                          final HostnameVerifier hostnameVerifier, Tracer tracer, boolean traceWithActiveSpanOnly) {
+    super(poolConfig, uri, timeout, sslSocketFactory, sslParameters, hostnameVerifier);
+    this.tracer = tracer;
+    this.traceWithActiveSpanOnly = traceWithActiveSpanOnly;
+  }
+
+  public TracingJedisPool(final GenericObjectPoolConfig poolConfig, final URI uri, final int connectionTimeout,
+                          final int soTimeout, Tracer tracer, boolean traceWithActiveSpanOnly) {
+    super(poolConfig, uri, connectionTimeout, soTimeout);
+    this.tracer = tracer;
+    this.traceWithActiveSpanOnly = traceWithActiveSpanOnly;
+
+  }
+
+  public TracingJedisPool(final GenericObjectPoolConfig poolConfig, final URI uri, final int connectionTimeout,
+                          final int soTimeout, final SSLSocketFactory sslSocketFactory, final SSLParameters sslParameters,
+                          final HostnameVerifier hostnameVerifier, Tracer tracer, boolean traceWithActiveSpanOnly) {
+    super(poolConfig, uri, connectionTimeout, soTimeout, sslSocketFactory, sslParameters, hostnameVerifier);
+    this.tracer = tracer;
+    this.traceWithActiveSpanOnly = traceWithActiveSpanOnly;
+
+  }
+
+  @Override
+  public Jedis getResource() {
+    Jedis resource = super.getResource();
+
+    return new TracingJedisWrapper(resource, tracer, traceWithActiveSpanOnly);
+  }
+
+  /**
+   * @deprecated See {@link redis.clients.jedis.JedisPool#returnBrokenResource}
+   */
+  @Override
+  @Deprecated
+  public void returnBrokenResource(final Jedis resource) {
+    super.returnBrokenResource(unwrapResource(resource));
+  }
+
+  /**
+   * @deprecated See {@link redis.clients.jedis.JedisPool#returnResource}
+   */
+  @Override
+  @Deprecated
+  public void returnResource(final Jedis resource) {
+    super.returnResource(unwrapResource(resource));
+  }
+
+  /**
+   * @deprecated See {@link redis.clients.util.Pool#returnResourceObject}
+   */
+  @Override
+  @Deprecated
+  public void returnResourceObject(final Jedis resource) {
+    super.returnResourceObject(unwrapResource(resource));
+  }
+
+  private Jedis unwrapResource(Jedis resource) {
+    return (resource instanceof TracingJedisWrapper)
+        ? ((TracingJedisWrapper) resource).getWrapped()
+        : resource;
+  }
+
+  /**
+   * TracingJedisWrapper wraps Jedis object, usually at the moment of extraction from the Pool.
+   * Used to provide tracing capabilities to redis commands executed by the client provided by
+   * given Jedis object.
+   */
+  private class TracingJedisWrapper extends TracingJedis {
+    private final Jedis wrapped;
+
+    public TracingJedisWrapper(Jedis jedis, Tracer tracer, boolean traceWithActiveSpanOnly) {
+      super(tracer, traceWithActiveSpanOnly);
+      this.client = jedis.getClient();
+      this.wrapped = jedis;
+    }
+
+    @Override
+    public void close() {
+      super.close();
+      wrapped.close();
+    }
+
+    public Jedis getWrapped() {
+      return wrapped;
+    }
+  }
+}

--- a/opentracing-redis-jedis/src/main/java/io/opentracing/contrib/redis/jedis/TracingJedisPool.java
+++ b/opentracing-redis-jedis/src/main/java/io/opentracing/contrib/redis/jedis/TracingJedisPool.java
@@ -14,7 +14,6 @@ public class TracingJedisPool extends JedisPool {
   private final Tracer tracer;
   private final boolean traceWithActiveSpanOnly;
 
-
   public TracingJedisPool(Tracer tracer, boolean traceWithActiveSpanOnly) {
     super();
     this.tracer = tracer;

--- a/opentracing-redis-jedis/src/test/java/io/opentracing/contrib/redis/jedis/TracingJedisPoolTest.java
+++ b/opentracing-redis-jedis/src/test/java/io/opentracing/contrib/redis/jedis/TracingJedisPoolTest.java
@@ -1,7 +1,69 @@
 package io.opentracing.contrib.redis.jedis;
 
-/**
- * Created by admin on 28/03/2018.
- */
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.util.ThreadLocalScopeManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.embedded.RedisServer;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
 public class TracingJedisPoolTest {
+
+  private MockTracer mockTracer = new MockTracer(new ThreadLocalScopeManager(),
+      MockTracer.Propagator.TEXT_MAP);
+
+  private RedisServer redisServer;
+
+  @Before
+  public void before() throws Exception {
+    mockTracer.reset();
+
+    redisServer = RedisServer.builder().setting("bind 127.0.0.1").build();
+    redisServer.start();
+  }
+
+  @After
+  public void after() {
+    if (redisServer != null) {
+      redisServer.stop();
+    }
+  }
+
+  @Test
+  public void testPoolReturnsTracedJedis() {
+    JedisPool pool = new TracingJedisPool(mockTracer, false);
+
+    Jedis jedis = pool.getResource();
+    assertEquals("OK", jedis.set("key", "value"));
+    assertEquals("value", jedis.get("key"));
+
+    jedis.close();
+
+    List<MockSpan> spans = mockTracer.finishedSpans();
+    assertEquals(2, spans.size());
+  }
+
+  @Test
+  public void testClosingTracedJedisClosesUnderlyingJedis() {
+    JedisPool pool = new TracingJedisPool(mockTracer, false);
+    Jedis resource = pool.getResource();
+    assertEquals(1, pool.getNumActive());
+
+    resource.close();
+    assertEquals(0, pool.getNumActive());
+    assertEquals(1, pool.getNumIdle());
+
+    // ensure that resource is reused
+    Jedis nextResource = pool.getResource();
+    assertEquals(1, pool.getNumActive());
+    assertEquals(0, pool.getNumIdle());
+    nextResource.close();
+  }
 }

--- a/opentracing-redis-jedis/src/test/java/io/opentracing/contrib/redis/jedis/TracingJedisPoolTest.java
+++ b/opentracing-redis-jedis/src/test/java/io/opentracing/contrib/redis/jedis/TracingJedisPoolTest.java
@@ -1,0 +1,7 @@
+package io.opentracing.contrib.redis.jedis;
+
+/**
+ * Created by admin on 28/03/2018.
+ */
+public class TracingJedisPoolTest {
+}

--- a/opentracing-redis-jedis/src/test/java/io/opentracing/contrib/redis/jedis/TracingJedisPoolTest.java
+++ b/opentracing-redis-jedis/src/test/java/io/opentracing/contrib/redis/jedis/TracingJedisPoolTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.redis.jedis;
 
 import io.opentracing.mock.MockSpan;


### PR DESCRIPTION
Hi there! Just wanted to discuss the idea of having `JedisPool` class traced.
Why should it be traced at all? Well, because it provides a good way to control "population" of `Jedis` instances. (also [here](https://github.com/xetorthio/jedis/wiki/Getting-started#using-jedis-in-a-multithreaded-environment) are some details).
However, implementation of `Jedis` makes it problematic to wrap, because it's a class. Everything would be simpler if it was an interface. That's why `TracingJedisPool` relies upon a tricky `TracingJedisWrapper`.
I noticed, that `Jedis` objects are extracted from pool in "closed" state and return back to the pool in "closed" state again (because the object is returned by calling `close()` method). That's why it's safe to assume that it's `Jedis#client` property that we should care about. Therefore, the logic is to create regular `TracingJedis` instance with default constructor (it doesn't open a connection, just creates a `Client` object) and substitute the client.

There is no tests yet, because it's a draft I'd like to discuss first.

What do you think?