### PR TITLE
Continue Span in stages of RedisFuture

### DIFF
--- a/opentracing-redis-lettuce/src/main/java/io/opentracing/contrib/redis/lettuce/CompletableRedisFuture.java
+++ b/opentracing-redis-lettuce/src/main/java/io/opentracing/contrib/redis/lettuce/CompletableRedisFuture.java
@@ -1,0 +1,25 @@
+package io.opentracing.contrib.redis.lettuce;
+
+import io.lettuce.core.RedisFuture;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+public class CompletableRedisFuture<T> extends CompletableFuture<T> implements RedisFuture<T> {
+
+    private RedisFuture<T> wrappedFuture;
+
+    public CompletableRedisFuture(RedisFuture<T> wrappedFuture) {
+        this.wrappedFuture = wrappedFuture;
+    }
+
+    @Override
+    public String getError() {
+        return wrappedFuture.getError();
+    }
+
+    @Override
+    public boolean await(long timeout, TimeUnit unit) throws InterruptedException {
+        return wrappedFuture.await(timeout,unit);
+    }
+}

--- a/opentracing-redis-lettuce/src/main/java/io/opentracing/contrib/redis/lettuce/CompletableRedisFuture.java
+++ b/opentracing-redis-lettuce/src/main/java/io/opentracing/contrib/redis/lettuce/CompletableRedisFuture.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.redis.lettuce;
 
 import io.lettuce.core.RedisFuture;

--- a/opentracing-redis-lettuce/src/main/java/io/opentracing/contrib/redis/lettuce/TracingRedisAsyncCommands.java
+++ b/opentracing-redis-lettuce/src/main/java/io/opentracing/contrib/redis/lettuce/TracingRedisAsyncCommands.java
@@ -53,6 +53,7 @@ import io.lettuce.core.output.ValueStreamingChannel;
 import io.lettuce.core.protocol.CommandArgs;
 import io.lettuce.core.protocol.CommandType;
 import io.lettuce.core.protocol.ProtocolKeyword;
+import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
 import io.opentracing.contrib.redis.common.TracingHelper;
@@ -122,7 +123,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     span.setTag("db1", db1);
     span.setTag("db2", db2);
     try {
-      return setCompleteAction(commands.swapdb(db1, db2), span);
+      return prepareRedisFuture(commands.swapdb(db1, db2), span);
     } catch (Exception e) {
       onError(e, span);
       throw e;
@@ -140,119 +141,119 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
   @Override
   public RedisFuture<Long> hdel(K key, K... fields) {
     Span span = helper.buildSpan("hdel", key);
-    return setCompleteAction(commands.hdel(key, fields), span);
+    return prepareRedisFuture(commands.hdel(key, fields), span);
   }
 
   @Override
   public RedisFuture<Boolean> hexists(K key, K field) {
     Span span = helper.buildSpan("hexists", key);
-    return setCompleteAction(commands.hexists(key, field), span);
+    return prepareRedisFuture(commands.hexists(key, field), span);
   }
 
   @Override
   public RedisFuture<V> hget(K key, K field) {
     Span span = helper.buildSpan("hget", key);
-    return setCompleteAction(commands.hget(key, field), span);
+    return prepareRedisFuture(commands.hget(key, field), span);
   }
 
   @Override
   public RedisFuture<Long> hincrby(K key, K field, long amount) {
     Span span = helper.buildSpan("hincrby", key);
     span.setTag("amount", amount);
-    return setCompleteAction(commands.hincrby(key, field, amount), span);
+    return prepareRedisFuture(commands.hincrby(key, field, amount), span);
   }
 
   @Override
   public RedisFuture<Double> hincrbyfloat(K key, K field, double amount) {
     Span span = helper.buildSpan("hincrbyfloat", key);
     span.setTag("amount", amount);
-    return setCompleteAction(commands.hincrbyfloat(key, field, amount), span);
+    return prepareRedisFuture(commands.hincrbyfloat(key, field, amount), span);
   }
 
   @Override
   public RedisFuture<Map<K, V>> hgetall(K key) {
     Span span = helper.buildSpan("hgetall", key);
-    return setCompleteAction(commands.hgetall(key), span);
+    return prepareRedisFuture(commands.hgetall(key), span);
   }
 
   @Override
   public RedisFuture<Long> hgetall(
       KeyValueStreamingChannel<K, V> channel, K key) {
     Span span = helper.buildSpan("hgetall", key);
-    return setCompleteAction(commands.hgetall(channel, key), span);
+    return prepareRedisFuture(commands.hgetall(channel, key), span);
   }
 
   @Override
   public RedisFuture<List<K>> hkeys(K key) {
     Span span = helper.buildSpan("hkeys", key);
-    return setCompleteAction(commands.hkeys(key), span);
+    return prepareRedisFuture(commands.hkeys(key), span);
   }
 
   @Override
   public RedisFuture<Long> hkeys(
       KeyStreamingChannel<K> channel, K key) {
     Span span = helper.buildSpan("hkeys", key);
-    return setCompleteAction(commands.hkeys(channel, key), span);
+    return prepareRedisFuture(commands.hkeys(channel, key), span);
   }
 
   @Override
   public RedisFuture<Long> hlen(K key) {
     Span span = helper.buildSpan("hlen", key);
-    return setCompleteAction(commands.hlen(key), span);
+    return prepareRedisFuture(commands.hlen(key), span);
   }
 
   @Override
   public RedisFuture<List<KeyValue<K, V>>> hmget(K key,
       K... fields) {
     Span span = helper.buildSpan("hmget", key);
-    return setCompleteAction(commands.hmget(key, fields), span);
+    return prepareRedisFuture(commands.hmget(key, fields), span);
   }
 
   @Override
   public RedisFuture<Long> hmget(
       KeyValueStreamingChannel<K, V> channel, K key, K... fields) {
     Span span = helper.buildSpan("hmget", key);
-    return setCompleteAction(commands.hmget(channel, key, fields), span);
+    return prepareRedisFuture(commands.hmget(channel, key, fields), span);
   }
 
   @Override
   public RedisFuture<String> hmset(K key, Map<K, V> map) {
     Span span = helper.buildSpan("hmset", key);
-    return setCompleteAction(commands.hmset(key, map), span);
+    return prepareRedisFuture(commands.hmset(key, map), span);
   }
 
   @Override
   public RedisFuture<MapScanCursor<K, V>> hscan(K key) {
     Span span = helper.buildSpan("hscan", key);
-    return setCompleteAction(commands.hscan(key), span);
+    return prepareRedisFuture(commands.hscan(key), span);
   }
 
   @Override
   public RedisFuture<MapScanCursor<K, V>> hscan(K key,
       ScanArgs scanArgs) {
     Span span = helper.buildSpan("hscan", key);
-    return setCompleteAction(commands.hscan(key, scanArgs), span);
+    return prepareRedisFuture(commands.hscan(key, scanArgs), span);
   }
 
   @Override
   public RedisFuture<MapScanCursor<K, V>> hscan(K key,
       ScanCursor scanCursor, ScanArgs scanArgs) {
     Span span = helper.buildSpan("hscan", key);
-    return setCompleteAction(commands.hscan(key, scanCursor, scanArgs), span);
+    return prepareRedisFuture(commands.hscan(key, scanCursor, scanArgs), span);
   }
 
   @Override
   public RedisFuture<MapScanCursor<K, V>> hscan(K key,
       ScanCursor scanCursor) {
     Span span = helper.buildSpan("hscan", key);
-    return setCompleteAction(commands.hscan(key, scanCursor), span);
+    return prepareRedisFuture(commands.hscan(key, scanCursor), span);
   }
 
   @Override
   public RedisFuture<StreamScanCursor> hscan(
       KeyValueStreamingChannel<K, V> channel, K key) {
     Span span = helper.buildSpan("hscan", key);
-    return setCompleteAction(commands.hscan(channel, key), span);
+    return prepareRedisFuture(commands.hscan(channel, key), span);
   }
 
   @Override
@@ -260,7 +261,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
       KeyValueStreamingChannel<K, V> channel, K key,
       ScanArgs scanArgs) {
     Span span = helper.buildSpan("hscan", key);
-    return setCompleteAction(commands.hscan(channel, key, scanArgs), span);
+    return prepareRedisFuture(commands.hscan(channel, key, scanArgs), span);
   }
 
   @Override
@@ -268,7 +269,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
       KeyValueStreamingChannel<K, V> channel, K key,
       ScanCursor scanCursor, ScanArgs scanArgs) {
     Span span = helper.buildSpan("hscan", key);
-    return setCompleteAction(commands.hscan(channel, key, scanCursor, scanArgs), span);
+    return prepareRedisFuture(commands.hscan(channel, key, scanCursor, scanArgs), span);
   }
 
   @Override
@@ -276,96 +277,96 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
       KeyValueStreamingChannel<K, V> channel, K key,
       ScanCursor scanCursor) {
     Span span = helper.buildSpan("hscan", key);
-    return setCompleteAction(commands.hscan(channel, key, scanCursor), span);
+    return prepareRedisFuture(commands.hscan(channel, key, scanCursor), span);
   }
 
   @Override
   public RedisFuture<Boolean> hset(K key, K field, V value) {
     Span span = helper.buildSpan("hset", key);
-    return setCompleteAction(commands.hset(key, field, value), span);
+    return prepareRedisFuture(commands.hset(key, field, value), span);
   }
 
   @Override
   public RedisFuture<Boolean> hsetnx(K key, K field, V value) {
     Span span = helper.buildSpan("hsetnx", key);
-    return setCompleteAction(commands.hsetnx(key, field, value), span);
+    return prepareRedisFuture(commands.hsetnx(key, field, value), span);
   }
 
   @Override
   public RedisFuture<Long> hstrlen(K key, K field) {
     Span span = helper.buildSpan("hstrlen", key);
-    return setCompleteAction(commands.hstrlen(key, field), span);
+    return prepareRedisFuture(commands.hstrlen(key, field), span);
   }
 
   @Override
   public RedisFuture<List<V>> hvals(K key) {
     Span span = helper.buildSpan("hvals", key);
-    return setCompleteAction(commands.hvals(key), span);
+    return prepareRedisFuture(commands.hvals(key), span);
   }
 
   @Override
   public RedisFuture<Long> hvals(
       ValueStreamingChannel<V> channel, K key) {
     Span span = helper.buildSpan("hvals", key);
-    return setCompleteAction(commands.hvals(channel, key), span);
+    return prepareRedisFuture(commands.hvals(channel, key), span);
   }
 
   @Override
   public RedisFuture<Long> del(K... keys) {
     Span span = helper.buildSpan("del", keys);
-    return setCompleteAction(commands.del(keys), span);
+    return prepareRedisFuture(commands.del(keys), span);
   }
 
   @Override
   public RedisFuture<Long> unlink(K... keys) {
     Span span = helper.buildSpan("unlink", keys);
-    return setCompleteAction(commands.unlink(keys), span);
+    return prepareRedisFuture(commands.unlink(keys), span);
   }
 
   @Override
   public RedisFuture<byte[]> dump(K key) {
     Span span = helper.buildSpan("dump", key);
-    return setCompleteAction(commands.dump(key), span);
+    return prepareRedisFuture(commands.dump(key), span);
   }
 
   @Override
   public RedisFuture<Long> exists(K... keys) {
     Span span = helper.buildSpan("exists", keys);
-    return setCompleteAction(commands.exists(keys), span);
+    return prepareRedisFuture(commands.exists(keys), span);
   }
 
   @Override
   public RedisFuture<Boolean> expire(K key, long seconds) {
     Span span = helper.buildSpan("expire", key);
     span.setTag("seconds", seconds);
-    return setCompleteAction(commands.expire(key, seconds), span);
+    return prepareRedisFuture(commands.expire(key, seconds), span);
   }
 
   @Override
   public RedisFuture<Boolean> expireat(K key, Date timestamp) {
     Span span = helper.buildSpan("expireat", key);
     span.setTag("timestamp", nullable(timestamp));
-    return setCompleteAction(commands.expireat(key, timestamp), span);
+    return prepareRedisFuture(commands.expireat(key, timestamp), span);
   }
 
   @Override
   public RedisFuture<Boolean> expireat(K key, long timestamp) {
     Span span = helper.buildSpan("expireat", key);
     span.setTag("timestamp", timestamp);
-    return setCompleteAction(commands.expireat(key, timestamp), span);
+    return prepareRedisFuture(commands.expireat(key, timestamp), span);
   }
 
   @Override
   public RedisFuture<List<K>> keys(K pattern) {
     Span span = helper.buildSpan("keys");
-    return setCompleteAction(commands.keys(pattern), span);
+    return prepareRedisFuture(commands.keys(pattern), span);
   }
 
   @Override
   public RedisFuture<Long> keys(KeyStreamingChannel<K> channel,
       K pattern) {
     Span span = helper.buildSpan("keys");
-    return setCompleteAction(commands.keys(channel, pattern), span);
+    return prepareRedisFuture(commands.keys(channel, pattern), span);
   }
 
   @Override
@@ -376,7 +377,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     span.setTag("port", port);
     span.setTag("db", db);
     span.setTag("timeout", timeout);
-    return setCompleteAction(commands.migrate(host, port, key, db, timeout), span);
+    return prepareRedisFuture(commands.migrate(host, port, key, db, timeout), span);
   }
 
   @Override
@@ -387,109 +388,109 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     span.setTag("port", port);
     span.setTag("db", db);
     span.setTag("timeout", timeout);
-    return setCompleteAction(commands.migrate(host, port, db, timeout, migrateArgs), span);
+    return prepareRedisFuture(commands.migrate(host, port, db, timeout, migrateArgs), span);
   }
 
   @Override
   public RedisFuture<Boolean> move(K key, int db) {
     Span span = helper.buildSpan("move", key);
     span.setTag("db", db);
-    return setCompleteAction(commands.move(key, db), span);
+    return prepareRedisFuture(commands.move(key, db), span);
   }
 
   @Override
   public RedisFuture<String> objectEncoding(K key) {
     Span span = helper.buildSpan("objectEncoding", key);
-    return setCompleteAction(commands.objectEncoding(key), span);
+    return prepareRedisFuture(commands.objectEncoding(key), span);
   }
 
   @Override
   public RedisFuture<Long> objectIdletime(K key) {
     Span span = helper.buildSpan("objectIdletime", key);
-    return setCompleteAction(commands.objectIdletime(key), span);
+    return prepareRedisFuture(commands.objectIdletime(key), span);
   }
 
   @Override
   public RedisFuture<Long> objectRefcount(K key) {
     Span span = helper.buildSpan("objectRefcount", key);
-    return setCompleteAction(commands.objectRefcount(key), span);
+    return prepareRedisFuture(commands.objectRefcount(key), span);
   }
 
   @Override
   public RedisFuture<Boolean> persist(K key) {
     Span span = helper.buildSpan("persist", key);
-    return setCompleteAction(commands.persist(key), span);
+    return prepareRedisFuture(commands.persist(key), span);
   }
 
   @Override
   public RedisFuture<Boolean> pexpire(K key, long milliseconds) {
     Span span = helper.buildSpan("pexpire", key);
     span.setTag("milliseconds", milliseconds);
-    return setCompleteAction(commands.pexpire(key, milliseconds), span);
+    return prepareRedisFuture(commands.pexpire(key, milliseconds), span);
   }
 
   @Override
   public RedisFuture<Boolean> pexpireat(K key, Date timestamp) {
     Span span = helper.buildSpan("pexpireat", key);
     span.setTag("timestamp", nullable(timestamp));
-    return setCompleteAction(commands.pexpireat(key, timestamp), span);
+    return prepareRedisFuture(commands.pexpireat(key, timestamp), span);
   }
 
   @Override
   public RedisFuture<Boolean> pexpireat(K key, long timestamp) {
     Span span = helper.buildSpan("pexpireat", key);
     span.setTag("timestamp", timestamp);
-    return setCompleteAction(commands.pexpireat(key, timestamp), span);
+    return prepareRedisFuture(commands.pexpireat(key, timestamp), span);
   }
 
   @Override
   public RedisFuture<Long> pttl(K key) {
     Span span = helper.buildSpan("pttl", key);
-    return setCompleteAction(commands.pttl(key), span);
+    return prepareRedisFuture(commands.pttl(key), span);
   }
 
   @Override
   public RedisFuture<V> randomkey() {
     Span span = helper.buildSpan("randomkey");
-    return setCompleteAction(commands.randomkey(), span);
+    return prepareRedisFuture(commands.randomkey(), span);
   }
 
   @Override
   public RedisFuture<String> rename(K key, K newKey) {
     Span span = helper.buildSpan("rename", key);
-    return setCompleteAction(commands.rename(key, newKey), span);
+    return prepareRedisFuture(commands.rename(key, newKey), span);
   }
 
   @Override
   public RedisFuture<Boolean> renamenx(K key, K newKey) {
     Span span = helper.buildSpan("renamenx", key);
-    return setCompleteAction(commands.renamenx(key, newKey), span);
+    return prepareRedisFuture(commands.renamenx(key, newKey), span);
   }
 
   @Override
   public RedisFuture<String> restore(K key, long ttl, byte[] value) {
     Span span = helper.buildSpan("restore", key);
     span.setTag("ttl", ttl);
-    return setCompleteAction(commands.restore(key, ttl, value), span);
+    return prepareRedisFuture(commands.restore(key, ttl, value), span);
   }
 
   @Override
   public RedisFuture<List<V>> sort(K key) {
     Span span = helper.buildSpan("sort", key);
-    return setCompleteAction(commands.sort(key), span);
+    return prepareRedisFuture(commands.sort(key), span);
   }
 
   @Override
   public RedisFuture<Long> sort(
       ValueStreamingChannel<V> channel, K key) {
     Span span = helper.buildSpan("sort", key);
-    return setCompleteAction(commands.sort(channel, key), span);
+    return prepareRedisFuture(commands.sort(channel, key), span);
   }
 
   @Override
   public RedisFuture<List<V>> sort(K key, SortArgs sortArgs) {
     Span span = helper.buildSpan("sort", key);
-    return setCompleteAction(commands.sort(key, sortArgs), span);
+    return prepareRedisFuture(commands.sort(key, sortArgs), span);
   }
 
   @Override
@@ -497,73 +498,73 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
       ValueStreamingChannel<V> channel, K key,
       SortArgs sortArgs) {
     Span span = helper.buildSpan("sort", key);
-    return setCompleteAction(commands.sort(channel, key, sortArgs), span);
+    return prepareRedisFuture(commands.sort(channel, key, sortArgs), span);
   }
 
   @Override
   public RedisFuture<Long> sortStore(K key, SortArgs sortArgs,
       K destination) {
     Span span = helper.buildSpan("sortStore", key);
-    return setCompleteAction(commands.sortStore(key, sortArgs, destination), span);
+    return prepareRedisFuture(commands.sortStore(key, sortArgs, destination), span);
   }
 
   @Override
   public RedisFuture<Long> touch(K... keys) {
     Span span = helper.buildSpan("touch", keys);
-    return setCompleteAction(commands.touch(keys), span);
+    return prepareRedisFuture(commands.touch(keys), span);
   }
 
   @Override
   public RedisFuture<Long> ttl(K key) {
     Span span = helper.buildSpan("ttl", key);
-    return setCompleteAction(commands.ttl(key), span);
+    return prepareRedisFuture(commands.ttl(key), span);
   }
 
   @Override
   public RedisFuture<String> type(K key) {
     Span span = helper.buildSpan("type", key);
-    return setCompleteAction(commands.type(key), span);
+    return prepareRedisFuture(commands.type(key), span);
   }
 
   @Override
   public RedisFuture<KeyScanCursor<K>> scan() {
     Span span = helper.buildSpan("scan");
-    return setCompleteAction(commands.scan(), span);
+    return prepareRedisFuture(commands.scan(), span);
   }
 
   @Override
   public RedisFuture<KeyScanCursor<K>> scan(
       ScanArgs scanArgs) {
     Span span = helper.buildSpan("scan");
-    return setCompleteAction(commands.scan(scanArgs), span);
+    return prepareRedisFuture(commands.scan(scanArgs), span);
   }
 
   @Override
   public RedisFuture<KeyScanCursor<K>> scan(
       ScanCursor scanCursor, ScanArgs scanArgs) {
     Span span = helper.buildSpan("scan");
-    return setCompleteAction(commands.scan(scanCursor, scanArgs), span);
+    return prepareRedisFuture(commands.scan(scanCursor, scanArgs), span);
   }
 
   @Override
   public RedisFuture<KeyScanCursor<K>> scan(
       ScanCursor scanCursor) {
     Span span = helper.buildSpan("scan");
-    return setCompleteAction(commands.scan(scanCursor), span);
+    return prepareRedisFuture(commands.scan(scanCursor), span);
   }
 
   @Override
   public RedisFuture<StreamScanCursor> scan(
       KeyStreamingChannel<K> channel) {
     Span span = helper.buildSpan("scan");
-    return setCompleteAction(commands.scan(channel), span);
+    return prepareRedisFuture(commands.scan(channel), span);
   }
 
   @Override
   public RedisFuture<StreamScanCursor> scan(
       KeyStreamingChannel<K> channel, ScanArgs scanArgs) {
     Span span = helper.buildSpan("scan");
-    return setCompleteAction(commands.scan(channel, scanArgs), span);
+    return prepareRedisFuture(commands.scan(channel, scanArgs), span);
   }
 
   @Override
@@ -571,26 +572,26 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
       KeyStreamingChannel<K> channel, ScanCursor scanCursor,
       ScanArgs scanArgs) {
     Span span = helper.buildSpan("scan");
-    return setCompleteAction(commands.scan(channel, scanCursor, scanArgs), span);
+    return prepareRedisFuture(commands.scan(channel, scanCursor, scanArgs), span);
   }
 
   @Override
   public RedisFuture<StreamScanCursor> scan(
       KeyStreamingChannel<K> channel, ScanCursor scanCursor) {
     Span span = helper.buildSpan("scan");
-    return setCompleteAction(commands.scan(channel, scanCursor), span);
+    return prepareRedisFuture(commands.scan(channel, scanCursor), span);
   }
 
   @Override
   public RedisFuture<Long> append(K key, V value) {
     Span span = helper.buildSpan("append", key);
-    return setCompleteAction(commands.append(key, value), span);
+    return prepareRedisFuture(commands.append(key, value), span);
   }
 
   @Override
   public RedisFuture<Long> bitcount(K key) {
     Span span = helper.buildSpan("bitcount", key);
-    return setCompleteAction(commands.bitcount(key), span);
+    return prepareRedisFuture(commands.bitcount(key), span);
   }
 
   @Override
@@ -598,21 +599,21 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("bitcount", key);
     span.setTag("start", start);
     span.setTag("end", end);
-    return setCompleteAction(commands.bitcount(key, start, end), span);
+    return prepareRedisFuture(commands.bitcount(key, start, end), span);
   }
 
   @Override
   public RedisFuture<List<Long>> bitfield(K key,
       BitFieldArgs bitFieldArgs) {
     Span span = helper.buildSpan("bitfield", key);
-    return setCompleteAction(commands.bitfield(key, bitFieldArgs), span);
+    return prepareRedisFuture(commands.bitfield(key, bitFieldArgs), span);
   }
 
   @Override
   public RedisFuture<Long> bitpos(K key, boolean state) {
     Span span = helper.buildSpan("bitpos", key);
     span.setTag("state", state);
-    return setCompleteAction(commands.bitpos(key, state), span);
+    return prepareRedisFuture(commands.bitpos(key, state), span);
   }
 
   @Override
@@ -620,7 +621,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("bitpos", key);
     span.setTag("state", state);
     span.setTag("start", start);
-    return setCompleteAction(commands.bitpos(key, state, start), span);
+    return prepareRedisFuture(commands.bitpos(key, state, start), span);
   }
 
   @Override
@@ -629,57 +630,57 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     span.setTag("state", state);
     span.setTag("start", start);
     span.setTag("end", end);
-    return setCompleteAction(commands.bitpos(key, state, start, end), span);
+    return prepareRedisFuture(commands.bitpos(key, state, start, end), span);
   }
 
   @Override
   public RedisFuture<Long> bitopAnd(K destination, K... keys) {
     Span span = helper.buildSpan("bitopAnd", keys);
-    return setCompleteAction(commands.bitopAnd(destination, keys), span);
+    return prepareRedisFuture(commands.bitopAnd(destination, keys), span);
   }
 
   @Override
   public RedisFuture<Long> bitopNot(K destination, K source) {
     Span span = helper.buildSpan("bitopNot");
-    return setCompleteAction(commands.bitopNot(destination, source), span);
+    return prepareRedisFuture(commands.bitopNot(destination, source), span);
   }
 
   @Override
   public RedisFuture<Long> bitopOr(K destination, K... keys) {
     Span span = helper.buildSpan("bitopOr", keys);
-    return setCompleteAction(commands.bitopOr(destination, keys), span);
+    return prepareRedisFuture(commands.bitopOr(destination, keys), span);
   }
 
   @Override
   public RedisFuture<Long> bitopXor(K destination, K... keys) {
     Span span = helper.buildSpan("bitopXor", keys);
-    return setCompleteAction(commands.bitopXor(destination, keys), span);
+    return prepareRedisFuture(commands.bitopXor(destination, keys), span);
   }
 
   @Override
   public RedisFuture<Long> decr(K key) {
     Span span = helper.buildSpan("decr", key);
-    return setCompleteAction(commands.decr(key), span);
+    return prepareRedisFuture(commands.decr(key), span);
   }
 
   @Override
   public RedisFuture<Long> decrby(K key, long amount) {
     Span span = helper.buildSpan("decrby", key);
     span.setTag("amount", amount);
-    return setCompleteAction(commands.decrby(key, amount), span);
+    return prepareRedisFuture(commands.decrby(key, amount), span);
   }
 
   @Override
   public RedisFuture<V> get(K key) {
     Span span = helper.buildSpan("get", key);
-    return setCompleteAction(setCompleteAction(commands.get(key), span), span);
+    return prepareRedisFuture(prepareRedisFuture(commands.get(key), span), span);
   }
 
   @Override
   public RedisFuture<Long> getbit(K key, long offset) {
     Span span = helper.buildSpan("getbit", key);
     span.setTag("offset", offset);
-    return setCompleteAction(commands.getbit(key, offset), span);
+    return prepareRedisFuture(commands.getbit(key, offset), span);
   }
 
   @Override
@@ -687,70 +688,70 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("getrange", key);
     span.setTag("start", start);
     span.setTag("end", end);
-    return setCompleteAction(commands.getrange(key, start, end), span);
+    return prepareRedisFuture(commands.getrange(key, start, end), span);
   }
 
   @Override
   public RedisFuture<V> getset(K key, V value) {
     Span span = helper.buildSpan("getset", key);
-    return setCompleteAction(commands.getset(key, value), span);
+    return prepareRedisFuture(commands.getset(key, value), span);
   }
 
   @Override
   public RedisFuture<Long> incr(K key) {
     Span span = helper.buildSpan("incr", key);
-    return setCompleteAction(commands.incr(key), span);
+    return prepareRedisFuture(commands.incr(key), span);
   }
 
   @Override
   public RedisFuture<Long> incrby(K key, long amount) {
     Span span = helper.buildSpan("incrby", key);
     span.setTag("amount", amount);
-    return setCompleteAction(commands.incrby(key, amount), span);
+    return prepareRedisFuture(commands.incrby(key, amount), span);
   }
 
   @Override
   public RedisFuture<Double> incrbyfloat(K key, double amount) {
     Span span = helper.buildSpan("incrbyfloat", key);
     span.setTag("amount", amount);
-    return setCompleteAction(commands.incrbyfloat(key, amount), span);
+    return prepareRedisFuture(commands.incrbyfloat(key, amount), span);
   }
 
   @Override
   public RedisFuture<List<KeyValue<K, V>>> mget(K... keys) {
     Span span = helper.buildSpan("mget", keys);
-    return setCompleteAction(commands.mget(keys), span);
+    return prepareRedisFuture(commands.mget(keys), span);
   }
 
   @Override
   public RedisFuture<Long> mget(
       KeyValueStreamingChannel<K, V> channel, K... keys) {
     Span span = helper.buildSpan("mget", keys);
-    return setCompleteAction(commands.mget(channel, keys), span);
+    return prepareRedisFuture(commands.mget(channel, keys), span);
   }
 
   @Override
   public RedisFuture<String> mset(Map<K, V> map) {
     Span span = helper.buildSpan("mset");
-    return setCompleteAction(commands.mset(map), span);
+    return prepareRedisFuture(commands.mset(map), span);
   }
 
   @Override
   public RedisFuture<Boolean> msetnx(Map<K, V> map) {
     Span span = helper.buildSpan("msetnx");
-    return setCompleteAction(commands.msetnx(map), span);
+    return prepareRedisFuture(commands.msetnx(map), span);
   }
 
   @Override
   public RedisFuture<String> set(K key, V value) {
     Span span = helper.buildSpan("set", key);
-    return setCompleteAction(setCompleteAction(commands.set(key, value), span), span);
+    return prepareRedisFuture(prepareRedisFuture(commands.set(key, value), span), span);
   }
 
   @Override
   public RedisFuture<String> set(K key, V value, SetArgs setArgs) {
     Span span = helper.buildSpan("set", key);
-    return setCompleteAction(commands.set(key, value, setArgs), span);
+    return prepareRedisFuture(commands.set(key, value, setArgs), span);
   }
 
   @Override
@@ -758,99 +759,99 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("setbit", key);
     span.setTag("offset", offset);
     span.setTag("value", value);
-    return setCompleteAction(commands.setbit(key, offset, value), span);
+    return prepareRedisFuture(commands.setbit(key, offset, value), span);
   }
 
   @Override
   public RedisFuture<String> setex(K key, long seconds, V value) {
     Span span = helper.buildSpan("setex", key);
     span.setTag("seconds", seconds);
-    return setCompleteAction(commands.setex(key, seconds, value), span);
+    return prepareRedisFuture(commands.setex(key, seconds, value), span);
   }
 
   @Override
   public RedisFuture<String> psetex(K key, long milliseconds, V value) {
     Span span = helper.buildSpan("psetex", key);
     span.setTag("milliseconds", milliseconds);
-    return setCompleteAction(commands.psetex(key, milliseconds, value), span);
+    return prepareRedisFuture(commands.psetex(key, milliseconds, value), span);
   }
 
   @Override
   public RedisFuture<Boolean> setnx(K key, V value) {
     Span span = helper.buildSpan("setnx", key);
-    return setCompleteAction(commands.setnx(key, value), span);
+    return prepareRedisFuture(commands.setnx(key, value), span);
   }
 
   @Override
   public RedisFuture<Long> setrange(K key, long offset, V value) {
     Span span = helper.buildSpan("setrange", key);
     span.setTag("offset", offset);
-    return setCompleteAction(commands.setrange(key, offset, value), span);
+    return prepareRedisFuture(commands.setrange(key, offset, value), span);
   }
 
   @Override
   public RedisFuture<Long> strlen(K key) {
     Span span = helper.buildSpan("strlen", key);
-    return setCompleteAction(commands.strlen(key), span);
+    return prepareRedisFuture(commands.strlen(key), span);
   }
 
   @Override
   public RedisFuture<KeyValue<K, V>> blpop(long timeout, K... keys) {
     Span span = helper.buildSpan("blpop", keys);
     span.setTag("timeout", timeout);
-    return setCompleteAction(commands.blpop(timeout, keys), span);
+    return prepareRedisFuture(commands.blpop(timeout, keys), span);
   }
 
   @Override
   public RedisFuture<KeyValue<K, V>> brpop(long timeout, K... keys) {
     Span span = helper.buildSpan("brpop", keys);
     span.setTag("timeout", timeout);
-    return setCompleteAction(commands.brpop(timeout, keys), span);
+    return prepareRedisFuture(commands.brpop(timeout, keys), span);
   }
 
   @Override
   public RedisFuture<V> brpoplpush(long timeout, K source, K destination) {
     Span span = helper.buildSpan("brpoplpush");
     span.setTag("timeout", timeout);
-    return setCompleteAction(commands.brpoplpush(timeout, source, destination), span);
+    return prepareRedisFuture(commands.brpoplpush(timeout, source, destination), span);
   }
 
   @Override
   public RedisFuture<V> lindex(K key, long index) {
     Span span = helper.buildSpan("lindex", key);
     span.setTag("index", index);
-    return setCompleteAction(commands.lindex(key, index), span);
+    return prepareRedisFuture(commands.lindex(key, index), span);
   }
 
   @Override
   public RedisFuture<Long> linsert(K key, boolean before, V pivot, V value) {
     Span span = helper.buildSpan("linsert", key);
     span.setTag("before", before);
-    return setCompleteAction(commands.linsert(key, before, pivot, value), span);
+    return prepareRedisFuture(commands.linsert(key, before, pivot, value), span);
   }
 
   @Override
   public RedisFuture<Long> llen(K key) {
     Span span = helper.buildSpan("llen", key);
-    return setCompleteAction(commands.llen(key), span);
+    return prepareRedisFuture(commands.llen(key), span);
   }
 
   @Override
   public RedisFuture<V> lpop(K key) {
     Span span = helper.buildSpan("lpop", key);
-    return setCompleteAction(commands.lpop(key), span);
+    return prepareRedisFuture(commands.lpop(key), span);
   }
 
   @Override
   public RedisFuture<Long> lpush(K key, V... values) {
     Span span = helper.buildSpan("lpush", key);
-    return setCompleteAction(commands.lpush(key, values), span);
+    return prepareRedisFuture(commands.lpush(key, values), span);
   }
 
   @Override
   public RedisFuture<Long> lpushx(K key, V... values) {
     Span span = helper.buildSpan("lpushx", key);
-    return setCompleteAction(commands.lpushx(key, values), span);
+    return prepareRedisFuture(commands.lpushx(key, values), span);
   }
 
   @Override
@@ -858,7 +859,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("lrange", key);
     span.setTag("start", start);
     span.setTag("stop", stop);
-    return setCompleteAction(commands.lrange(key, start, stop), span);
+    return prepareRedisFuture(commands.lrange(key, start, stop), span);
   }
 
   @Override
@@ -867,21 +868,21 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("lrange", key);
     span.setTag("start", start);
     span.setTag("stop", stop);
-    return setCompleteAction(commands.lrange(channel, key, start, stop), span);
+    return prepareRedisFuture(commands.lrange(channel, key, start, stop), span);
   }
 
   @Override
   public RedisFuture<Long> lrem(K key, long count, V value) {
     Span span = helper.buildSpan("lrem", key);
     span.setTag("count", count);
-    return setCompleteAction(commands.lrem(key, count, value), span);
+    return prepareRedisFuture(commands.lrem(key, count, value), span);
   }
 
   @Override
   public RedisFuture<String> lset(K key, long index, V value) {
     Span span = helper.buildSpan("lset", key);
     span.setTag("index", index);
-    return setCompleteAction(commands.lset(key, index, value), span);
+    return prepareRedisFuture(commands.lset(key, index, value), span);
   }
 
   @Override
@@ -889,132 +890,132 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("ltrim", key);
     span.setTag("start", start);
     span.setTag("stop", stop);
-    return setCompleteAction(commands.ltrim(key, start, stop), span);
+    return prepareRedisFuture(commands.ltrim(key, start, stop), span);
   }
 
   @Override
   public RedisFuture<V> rpop(K key) {
     Span span = helper.buildSpan("rpop", key);
-    return setCompleteAction(commands.rpop(key), span);
+    return prepareRedisFuture(commands.rpop(key), span);
   }
 
   @Override
   public RedisFuture<V> rpoplpush(K source, K destination) {
     Span span = helper.buildSpan("rpoplpush");
-    return setCompleteAction(commands.rpoplpush(source, destination), span);
+    return prepareRedisFuture(commands.rpoplpush(source, destination), span);
   }
 
   @Override
   public RedisFuture<Long> rpush(K key, V... values) {
     Span span = helper.buildSpan("rpush", key);
-    return setCompleteAction(commands.rpush(key, values), span);
+    return prepareRedisFuture(commands.rpush(key, values), span);
   }
 
   @Override
   public RedisFuture<Long> rpushx(K key, V... values) {
     Span span = helper.buildSpan("rpushx", key);
-    return setCompleteAction(commands.rpushx(key, values), span);
+    return prepareRedisFuture(commands.rpushx(key, values), span);
   }
 
   @Override
   public RedisFuture<Long> sadd(K key, V... members) {
     Span span = helper.buildSpan("sadd", key);
-    return setCompleteAction(commands.sadd(key, members), span);
+    return prepareRedisFuture(commands.sadd(key, members), span);
   }
 
   @Override
   public RedisFuture<Long> scard(K key) {
     Span span = helper.buildSpan("scard", key);
-    return setCompleteAction(commands.scard(key), span);
+    return prepareRedisFuture(commands.scard(key), span);
   }
 
   @Override
   public RedisFuture<Set<V>> sdiff(K... keys) {
     Span span = helper.buildSpan("sdiff", keys);
-    return setCompleteAction(commands.sdiff(keys), span);
+    return prepareRedisFuture(commands.sdiff(keys), span);
   }
 
   @Override
   public RedisFuture<Long> sdiff(
       ValueStreamingChannel<V> channel, K... keys) {
     Span span = helper.buildSpan("sdiff", keys);
-    return setCompleteAction(commands.sdiff(channel, keys), span);
+    return prepareRedisFuture(commands.sdiff(channel, keys), span);
   }
 
   @Override
   public RedisFuture<Long> sdiffstore(K destination, K... keys) {
     Span span = helper.buildSpan("sdiffstore", keys);
-    return setCompleteAction(commands.sdiffstore(destination, keys), span);
+    return prepareRedisFuture(commands.sdiffstore(destination, keys), span);
   }
 
   @Override
   public RedisFuture<Set<V>> sinter(K... keys) {
     Span span = helper.buildSpan("sinter", keys);
-    return setCompleteAction(commands.sinter(keys), span);
+    return prepareRedisFuture(commands.sinter(keys), span);
   }
 
   @Override
   public RedisFuture<Long> sinter(
       ValueStreamingChannel<V> channel, K... keys) {
     Span span = helper.buildSpan("sinter", keys);
-    return setCompleteAction(commands.sinter(channel, keys), span);
+    return prepareRedisFuture(commands.sinter(channel, keys), span);
   }
 
   @Override
   public RedisFuture<Long> sinterstore(K destination, K... keys) {
     Span span = helper.buildSpan("sinterstore", keys);
-    return setCompleteAction(commands.sinterstore(destination, keys), span);
+    return prepareRedisFuture(commands.sinterstore(destination, keys), span);
   }
 
   @Override
   public RedisFuture<Boolean> sismember(K key, V member) {
     Span span = helper.buildSpan("sismember", key);
-    return setCompleteAction(commands.sismember(key, member), span);
+    return prepareRedisFuture(commands.sismember(key, member), span);
   }
 
   @Override
   public RedisFuture<Boolean> smove(K source, K destination, V member) {
     Span span = helper.buildSpan("smove");
-    return setCompleteAction(commands.smove(source, destination, member), span);
+    return prepareRedisFuture(commands.smove(source, destination, member), span);
   }
 
   @Override
   public RedisFuture<Set<V>> smembers(K key) {
     Span span = helper.buildSpan("smembers", key);
-    return setCompleteAction(commands.smembers(key), span);
+    return prepareRedisFuture(commands.smembers(key), span);
   }
 
   @Override
   public RedisFuture<Long> smembers(
       ValueStreamingChannel<V> channel, K key) {
     Span span = helper.buildSpan("smembers", key);
-    return setCompleteAction(commands.smembers(channel, key), span);
+    return prepareRedisFuture(commands.smembers(channel, key), span);
   }
 
   @Override
   public RedisFuture<V> spop(K key) {
     Span span = helper.buildSpan("spop", key);
-    return setCompleteAction(commands.spop(key), span);
+    return prepareRedisFuture(commands.spop(key), span);
   }
 
   @Override
   public RedisFuture<Set<V>> spop(K key, long count) {
     Span span = helper.buildSpan("spop", key);
     span.setTag("count", count);
-    return setCompleteAction(commands.spop(key, count), span);
+    return prepareRedisFuture(commands.spop(key, count), span);
   }
 
   @Override
   public RedisFuture<V> srandmember(K key) {
     Span span = helper.buildSpan("srandmember", key);
-    return setCompleteAction(commands.srandmember(key), span);
+    return prepareRedisFuture(commands.srandmember(key), span);
   }
 
   @Override
   public RedisFuture<List<V>> srandmember(K key, long count) {
     Span span = helper.buildSpan("srandmember", key);
     span.setTag("count", count);
-    return setCompleteAction(commands.srandmember(key, count), span);
+    return prepareRedisFuture(commands.srandmember(key, count), span);
   }
 
   @Override
@@ -1022,66 +1023,66 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
       ValueStreamingChannel<V> channel, K key, long count) {
     Span span = helper.buildSpan("srandmember", key);
     span.setTag("count", count);
-    return setCompleteAction(commands.srandmember(channel, key, count), span);
+    return prepareRedisFuture(commands.srandmember(channel, key, count), span);
   }
 
   @Override
   public RedisFuture<Long> srem(K key, V... members) {
     Span span = helper.buildSpan("srem", key);
-    return setCompleteAction(commands.srem(key, members), span);
+    return prepareRedisFuture(commands.srem(key, members), span);
   }
 
   @Override
   public RedisFuture<Set<V>> sunion(K... keys) {
     Span span = helper.buildSpan("sunion", keys);
-    return setCompleteAction(commands.sunion(keys), span);
+    return prepareRedisFuture(commands.sunion(keys), span);
   }
 
   @Override
   public RedisFuture<Long> sunion(
       ValueStreamingChannel<V> channel, K... keys) {
     Span span = helper.buildSpan("sunion", keys);
-    return setCompleteAction(commands.sunion(channel, keys), span);
+    return prepareRedisFuture(commands.sunion(channel, keys), span);
   }
 
   @Override
   public RedisFuture<Long> sunionstore(K destination, K... keys) {
     Span span = helper.buildSpan("sunionstore", keys);
-    return setCompleteAction(commands.sunionstore(destination, keys), span);
+    return prepareRedisFuture(commands.sunionstore(destination, keys), span);
   }
 
   @Override
   public RedisFuture<ValueScanCursor<V>> sscan(K key) {
     Span span = helper.buildSpan("sscan", key);
-    return setCompleteAction(commands.sscan(key), span);
+    return prepareRedisFuture(commands.sscan(key), span);
   }
 
   @Override
   public RedisFuture<ValueScanCursor<V>> sscan(K key,
       ScanArgs scanArgs) {
     Span span = helper.buildSpan("sscan", key);
-    return setCompleteAction(commands.sscan(key, scanArgs), span);
+    return prepareRedisFuture(commands.sscan(key, scanArgs), span);
   }
 
   @Override
   public RedisFuture<ValueScanCursor<V>> sscan(K key,
       ScanCursor scanCursor, ScanArgs scanArgs) {
     Span span = helper.buildSpan("sscan", key);
-    return setCompleteAction(commands.sscan(key, scanCursor, scanArgs), span);
+    return prepareRedisFuture(commands.sscan(key, scanCursor, scanArgs), span);
   }
 
   @Override
   public RedisFuture<ValueScanCursor<V>> sscan(K key,
       ScanCursor scanCursor) {
     Span span = helper.buildSpan("sscan", key);
-    return setCompleteAction(commands.sscan(key, scanCursor), span);
+    return prepareRedisFuture(commands.sscan(key, scanCursor), span);
   }
 
   @Override
   public RedisFuture<StreamScanCursor> sscan(
       ValueStreamingChannel<V> channel, K key) {
     Span span = helper.buildSpan("sscan", key);
-    return setCompleteAction(commands.sscan(channel, key), span);
+    return prepareRedisFuture(commands.sscan(channel, key), span);
   }
 
   @Override
@@ -1089,7 +1090,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
       ValueStreamingChannel<V> channel, K key,
       ScanArgs scanArgs) {
     Span span = helper.buildSpan("sscan", key);
-    return setCompleteAction(commands.sscan(channel, key, scanArgs), span);
+    return prepareRedisFuture(commands.sscan(channel, key, scanArgs), span);
   }
 
   @Override
@@ -1097,7 +1098,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
       ValueStreamingChannel<V> channel, K key,
       ScanCursor scanCursor, ScanArgs scanArgs) {
     Span span = helper.buildSpan("sscan", key);
-    return setCompleteAction(commands.sscan(channel, key, scanCursor, scanArgs), span);
+    return prepareRedisFuture(commands.sscan(channel, key, scanCursor, scanArgs), span);
   }
 
   @Override
@@ -1105,26 +1106,26 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
       ValueStreamingChannel<V> channel, K key,
       ScanCursor scanCursor) {
     Span span = helper.buildSpan("sscan", key);
-    return setCompleteAction(commands.sscan(channel, key, scanCursor), span);
+    return prepareRedisFuture(commands.sscan(channel, key, scanCursor), span);
   }
 
   @Override
   public RedisFuture<Long> zadd(K key, double score, V member) {
     Span span = helper.buildSpan("zadd", key);
     span.setTag("score", score);
-    return setCompleteAction(commands.zadd(key, score, member), span);
+    return prepareRedisFuture(commands.zadd(key, score, member), span);
   }
 
   @Override
   public RedisFuture<Long> zadd(K key, Object... scoresAndValues) {
     Span span = helper.buildSpan("zadd", key);
-    return setCompleteAction(commands.zadd(key, scoresAndValues), span);
+    return prepareRedisFuture(commands.zadd(key, scoresAndValues), span);
   }
 
   @Override
   public RedisFuture<Long> zadd(K key, ScoredValue<V>... scoredValues) {
     Span span = helper.buildSpan("zadd", key);
-    return setCompleteAction(commands.zadd(key, scoredValues), span);
+    return prepareRedisFuture(commands.zadd(key, scoredValues), span);
   }
 
   @Override
@@ -1132,28 +1133,28 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
       double score, V member) {
     Span span = helper.buildSpan("zadd", key);
     span.setTag("score", score);
-    return setCompleteAction(commands.zadd(key, zAddArgs, score, member), span);
+    return prepareRedisFuture(commands.zadd(key, zAddArgs, score, member), span);
   }
 
   @Override
   public RedisFuture<Long> zadd(K key, ZAddArgs zAddArgs,
       Object... scoresAndValues) {
     Span span = helper.buildSpan("zadd", key);
-    return setCompleteAction(commands.zadd(key, zAddArgs, scoresAndValues), span);
+    return prepareRedisFuture(commands.zadd(key, zAddArgs, scoresAndValues), span);
   }
 
   @Override
   public RedisFuture<Long> zadd(K key, ZAddArgs zAddArgs,
       ScoredValue<V>... scoredValues) {
     Span span = helper.buildSpan("zadd", key);
-    return setCompleteAction(commands.zadd(key, zAddArgs, scoredValues), span);
+    return prepareRedisFuture(commands.zadd(key, zAddArgs, scoredValues), span);
   }
 
   @Override
   public RedisFuture<Double> zaddincr(K key, double score, V member) {
     Span span = helper.buildSpan("zaddincr", key);
     span.setTag("score", score);
-    return setCompleteAction(commands.zaddincr(key, score, member), span);
+    return prepareRedisFuture(commands.zaddincr(key, score, member), span);
   }
 
   @Override
@@ -1161,13 +1162,13 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
       double score, V member) {
     Span span = helper.buildSpan("zaddincr", key);
     span.setTag("score", score);
-    return setCompleteAction(commands.zaddincr(key, zAddArgs, score, member), span);
+    return prepareRedisFuture(commands.zaddincr(key, zAddArgs, score, member), span);
   }
 
   @Override
   public RedisFuture<Long> zcard(K key) {
     Span span = helper.buildSpan("zcard", key);
-    return setCompleteAction(commands.zcard(key), span);
+    return prepareRedisFuture(commands.zcard(key), span);
   }
 
   @Override
@@ -1176,7 +1177,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zcount", key);
     span.setTag("min", min);
     span.setTag("max", max);
-    return setCompleteAction(commands.zcount(key, min, max), span);
+    return prepareRedisFuture(commands.zcount(key, min, max), span);
   }
 
   @Override
@@ -1185,7 +1186,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zcount", key);
     span.setTag("min", min);
     span.setTag("max", max);
-    return setCompleteAction(commands.zcount(key, min, max), span);
+    return prepareRedisFuture(commands.zcount(key, min, max), span);
   }
 
   @Override
@@ -1193,27 +1194,27 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
       Range<? extends Number> range) {
     Span span = helper.buildSpan("zcount", key);
     span.setTag("range", nullable(range));
-    return setCompleteAction(commands.zcount(key, range), span);
+    return prepareRedisFuture(commands.zcount(key, range), span);
   }
 
   @Override
   public RedisFuture<Double> zincrby(K key, double amount, K member) {
     Span span = helper.buildSpan("zincrby", key);
     span.setTag("amount", amount);
-    return setCompleteAction(commands.zincrby(key, amount, member), span);
+    return prepareRedisFuture(commands.zincrby(key, amount, member), span);
   }
 
   @Override
   public RedisFuture<Long> zinterstore(K destination, K... keys) {
     Span span = helper.buildSpan("zinterstore", keys);
-    return setCompleteAction(commands.zinterstore(destination, keys), span);
+    return prepareRedisFuture(commands.zinterstore(destination, keys), span);
   }
 
   @Override
   public RedisFuture<Long> zinterstore(K destination,
       ZStoreArgs storeArgs, K... keys) {
     Span span = helper.buildSpan("zinterstore", keys);
-    return setCompleteAction(commands.zinterstore(destination, storeArgs, keys), span);
+    return prepareRedisFuture(commands.zinterstore(destination, storeArgs, keys), span);
   }
 
   @Override
@@ -1222,14 +1223,14 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zlexcount", key);
     span.setTag("min", min);
     span.setTag("max", max);
-    return setCompleteAction(commands.zlexcount(key, min, max), span);
+    return prepareRedisFuture(commands.zlexcount(key, min, max), span);
   }
 
   @Override
   public RedisFuture<Long> zlexcount(K key, Range<? extends V> range) {
     Span span = helper.buildSpan("zlexcount", key);
     span.setTag("range", nullable(range));
-    return setCompleteAction(commands.zlexcount(key, range), span);
+    return prepareRedisFuture(commands.zlexcount(key, range), span);
   }
 
   @Override
@@ -1237,7 +1238,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrange", key);
     span.setTag("start", start);
     span.setTag("stop", stop);
-    return setCompleteAction(commands.zrange(key, start, stop), span);
+    return prepareRedisFuture(commands.zrange(key, start, stop), span);
   }
 
   @Override
@@ -1246,7 +1247,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrange", key);
     span.setTag("start", start);
     span.setTag("stop", stop);
-    return setCompleteAction(commands.zrange(channel, key, start, stop), span);
+    return prepareRedisFuture(commands.zrange(channel, key, start, stop), span);
   }
 
   @Override
@@ -1255,7 +1256,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrangeWithScores", key);
     span.setTag("start", start);
     span.setTag("stop", stop);
-    return setCompleteAction(commands.zrangeWithScores(key, start, stop), span);
+    return prepareRedisFuture(commands.zrangeWithScores(key, start, stop), span);
   }
 
   @Override
@@ -1264,7 +1265,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrangeWithScores", key);
     span.setTag("start", start);
     span.setTag("stop", stop);
-    return setCompleteAction(commands.zrangeWithScores(channel, key, start, stop), span);
+    return prepareRedisFuture(commands.zrangeWithScores(channel, key, start, stop), span);
   }
 
   @Override
@@ -1274,7 +1275,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrangebylex", key);
     span.setTag("min", min);
     span.setTag("max", max);
-    return setCompleteAction(commands.zrangebylex(key, min, max), span);
+    return prepareRedisFuture(commands.zrangebylex(key, min, max), span);
   }
 
   @Override
@@ -1282,7 +1283,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
       Range<? extends V> range) {
     Span span = helper.buildSpan("zrangebylex", key);
     span.setTag("range", nullable(range));
-    return setCompleteAction(commands.zrangebylex(key, range), span);
+    return prepareRedisFuture(commands.zrangebylex(key, range), span);
   }
 
   @Override
@@ -1294,7 +1295,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     span.setTag("max", max);
     span.setTag("offset", offset);
     span.setTag("count", count);
-    return setCompleteAction(commands.zrangebylex(key, min, max, offset, count), span);
+    return prepareRedisFuture(commands.zrangebylex(key, min, max, offset, count), span);
   }
 
   @Override
@@ -1303,7 +1304,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrangebylex", key);
     span.setTag("range", nullable(range));
     span.setTag("limit", nullable(limit));
-    return setCompleteAction(commands.zrangebylex(key, range, limit), span);
+    return prepareRedisFuture(commands.zrangebylex(key, range, limit), span);
   }
 
   @Override
@@ -1312,7 +1313,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrangebyscore", key);
     span.setTag("min", min);
     span.setTag("max", max);
-    return setCompleteAction(commands.zrangebyscore(key, min, max), span);
+    return prepareRedisFuture(commands.zrangebyscore(key, min, max), span);
   }
 
   @Override
@@ -1322,7 +1323,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrangebyscore", key);
     span.setTag("min", min);
     span.setTag("max", max);
-    return setCompleteAction(commands.zrangebyscore(key, min, max), span);
+    return prepareRedisFuture(commands.zrangebyscore(key, min, max), span);
   }
 
   @Override
@@ -1330,7 +1331,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
       Range<? extends Number> range) {
     Span span = helper.buildSpan("zrangebyscore", key);
     span.setTag("range", nullable(range));
-    return setCompleteAction(commands.zrangebyscore(key, range), span);
+    return prepareRedisFuture(commands.zrangebyscore(key, range), span);
   }
 
   @Override
@@ -1342,7 +1343,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     span.setTag("max", max);
     span.setTag("offset", offset);
     span.setTag("count", count);
-    return setCompleteAction(commands.zrangebyscore(key, min, max, offset, count), span);
+    return prepareRedisFuture(commands.zrangebyscore(key, min, max, offset, count), span);
   }
 
   @Override
@@ -1354,7 +1355,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     span.setTag("max", max);
     span.setTag("offset", offset);
     span.setTag("count", count);
-    return setCompleteAction(commands.zrangebyscore(key, min, max, offset, count), span);
+    return prepareRedisFuture(commands.zrangebyscore(key, min, max, offset, count), span);
   }
 
   @Override
@@ -1363,7 +1364,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrangebyscore", key);
     span.setTag("range", nullable(range));
     span.setTag("limit", nullable(limit));
-    return setCompleteAction(commands.zrangebyscore(key, range, limit), span);
+    return prepareRedisFuture(commands.zrangebyscore(key, range, limit), span);
   }
 
   @Override
@@ -1373,7 +1374,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrangebyscore", key);
     span.setTag("min", min);
     span.setTag("max", max);
-    return setCompleteAction(commands.zrangebyscore(channel, key, min, max), span);
+    return prepareRedisFuture(commands.zrangebyscore(channel, key, min, max), span);
   }
 
   @Override
@@ -1384,7 +1385,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrangebyscore", key);
     span.setTag("min", min);
     span.setTag("max", max);
-    return setCompleteAction(commands.zrangebyscore(channel, key, min, max), span);
+    return prepareRedisFuture(commands.zrangebyscore(channel, key, min, max), span);
   }
 
   @Override
@@ -1393,7 +1394,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
       Range<? extends Number> range) {
     Span span = helper.buildSpan("zrangebyscore", key);
     span.setTag("range", nullable(range));
-    return setCompleteAction(commands.zrangebyscore(channel, key, range), span);
+    return prepareRedisFuture(commands.zrangebyscore(channel, key, range), span);
   }
 
   @Override
@@ -1406,7 +1407,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     span.setTag("max", max);
     span.setTag("offset", offset);
     span.setTag("count", count);
-    return setCompleteAction(commands.zrangebyscore(channel, key, min, max, offset, count), span);
+    return prepareRedisFuture(commands.zrangebyscore(channel, key, min, max, offset, count), span);
   }
 
   @Override
@@ -1419,7 +1420,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     span.setTag("max", max);
     span.setTag("offset", offset);
     span.setTag("count", count);
-    return setCompleteAction(commands.zrangebyscore(channel, key, min, max, offset, count), span);
+    return prepareRedisFuture(commands.zrangebyscore(channel, key, min, max, offset, count), span);
   }
 
   @Override
@@ -1429,7 +1430,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrangebyscore", key);
     span.setTag("range", nullable(range));
     span.setTag("limit", nullable(limit));
-    return setCompleteAction(commands.zrangebyscore(channel, key, range, limit), span);
+    return prepareRedisFuture(commands.zrangebyscore(channel, key, range, limit), span);
   }
 
   @Override
@@ -1439,7 +1440,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrangebyscoreWithScores", key);
     span.setTag("min", min);
     span.setTag("max", max);
-    return setCompleteAction(commands.zrangebyscoreWithScores(key, min, max), span);
+    return prepareRedisFuture(commands.zrangebyscoreWithScores(key, min, max), span);
   }
 
   @Override
@@ -1449,7 +1450,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrangebyscoreWithScores", key);
     span.setTag("min", min);
     span.setTag("max", max);
-    return setCompleteAction(commands.zrangebyscoreWithScores(key, min, max), span);
+    return prepareRedisFuture(commands.zrangebyscoreWithScores(key, min, max), span);
   }
 
   @Override
@@ -1457,7 +1458,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
       K key, Range<? extends Number> range) {
     Span span = helper.buildSpan("zrangebyscoreWithScores", key);
     span.setTag("range", nullable(range));
-    return setCompleteAction(commands.zrangebyscoreWithScores(key, range), span);
+    return prepareRedisFuture(commands.zrangebyscoreWithScores(key, range), span);
   }
 
   @Override
@@ -1469,7 +1470,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     span.setTag("max", max);
     span.setTag("offset", offset);
     span.setTag("count", count);
-    return setCompleteAction(commands.zrangebyscoreWithScores(key, min, max, offset, count), span);
+    return prepareRedisFuture(commands.zrangebyscoreWithScores(key, min, max, offset, count), span);
   }
 
   @Override
@@ -1481,7 +1482,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     span.setTag("max", max);
     span.setTag("offset", offset);
     span.setTag("count", count);
-    return setCompleteAction(commands.zrangebyscoreWithScores(key, min, max, offset, count), span);
+    return prepareRedisFuture(commands.zrangebyscoreWithScores(key, min, max, offset, count), span);
   }
 
   @Override
@@ -1490,7 +1491,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrangebyscoreWithScores", key);
     span.setTag("range", nullable(range));
     span.setTag("limit", nullable(limit));
-    return setCompleteAction(commands.zrangebyscoreWithScores(key, range, limit), span);
+    return prepareRedisFuture(commands.zrangebyscoreWithScores(key, range, limit), span);
   }
 
   @Override
@@ -1500,7 +1501,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrangebyscoreWithScores", key);
     span.setTag("min", min);
     span.setTag("max", max);
-    return setCompleteAction(commands.zrangebyscoreWithScores(channel, key, min, max), span);
+    return prepareRedisFuture(commands.zrangebyscoreWithScores(channel, key, min, max), span);
   }
 
   @Override
@@ -1511,7 +1512,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrangebyscoreWithScores", key);
     span.setTag("min", min);
     span.setTag("max", max);
-    return setCompleteAction(commands.zrangebyscoreWithScores(channel, key, min, max), span);
+    return prepareRedisFuture(commands.zrangebyscoreWithScores(channel, key, min, max), span);
   }
 
   @Override
@@ -1520,7 +1521,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
       Range<? extends Number> range) {
     Span span = helper.buildSpan("zrangebyscoreWithScores", key);
     span.setTag("range", nullable(range));
-    return setCompleteAction(commands.zrangebyscoreWithScores(channel, key, range), span);
+    return prepareRedisFuture(commands.zrangebyscoreWithScores(channel, key, range), span);
   }
 
   @Override
@@ -1533,7 +1534,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     span.setTag("max", max);
     span.setTag("offset", offset);
     span.setTag("count", count);
-    return setCompleteAction(
+    return prepareRedisFuture(
         commands.zrangebyscoreWithScores(channel, key, min, max, offset, count), span);
   }
 
@@ -1547,7 +1548,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     span.setTag("max", max);
     span.setTag("offset", offset);
     span.setTag("count", count);
-    return setCompleteAction(
+    return prepareRedisFuture(
         commands.zrangebyscoreWithScores(channel, key, min, max, offset, count), span);
   }
 
@@ -1558,19 +1559,19 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrangebyscoreWithScores", key);
     span.setTag("range", nullable(range));
     span.setTag("limit", nullable(limit));
-    return setCompleteAction(commands.zrangebyscoreWithScores(channel, key, range, limit), span);
+    return prepareRedisFuture(commands.zrangebyscoreWithScores(channel, key, range, limit), span);
   }
 
   @Override
   public RedisFuture<Long> zrank(K key, V member) {
     Span span = helper.buildSpan("zrank", key);
-    return setCompleteAction(commands.zrank(key, member), span);
+    return prepareRedisFuture(commands.zrank(key, member), span);
   }
 
   @Override
   public RedisFuture<Long> zrem(K key, V... members) {
     Span span = helper.buildSpan("zrem", key);
-    return setCompleteAction(commands.zrem(key, members), span);
+    return prepareRedisFuture(commands.zrem(key, members), span);
   }
 
   @Override
@@ -1579,7 +1580,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zremrangebylex", key);
     span.setTag("min", min);
     span.setTag("max", max);
-    return setCompleteAction(commands.zremrangebylex(key, min, max), span);
+    return prepareRedisFuture(commands.zremrangebylex(key, min, max), span);
   }
 
   @Override
@@ -1587,7 +1588,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
       Range<? extends V> range) {
     Span span = helper.buildSpan("zremrangebylex", key);
     span.setTag("range", nullable(range));
-    return setCompleteAction(commands.zremrangebylex(key, range), span);
+    return prepareRedisFuture(commands.zremrangebylex(key, range), span);
   }
 
   @Override
@@ -1595,7 +1596,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zremrangebyrank", key);
     span.setTag("start", start);
     span.setTag("stop", stop);
-    return setCompleteAction(commands.zremrangebyrank(key, start, stop), span);
+    return prepareRedisFuture(commands.zremrangebyrank(key, start, stop), span);
   }
 
   @Override
@@ -1604,7 +1605,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zremrangebyscore", key);
     span.setTag("min", min);
     span.setTag("max", max);
-    return setCompleteAction(commands.zremrangebyscore(key, min, max), span);
+    return prepareRedisFuture(commands.zremrangebyscore(key, min, max), span);
   }
 
   @Override
@@ -1613,7 +1614,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zremrangebyscore", key);
     span.setTag("min", min);
     span.setTag("max", max);
-    return setCompleteAction(commands.zremrangebyscore(key, min, max), span);
+    return prepareRedisFuture(commands.zremrangebyscore(key, min, max), span);
   }
 
   @Override
@@ -1621,7 +1622,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
       Range<? extends Number> range) {
     Span span = helper.buildSpan("zremrangebyscore", key);
     span.setTag("range", nullable(range));
-    return setCompleteAction(commands.zremrangebyscore(key, range), span);
+    return prepareRedisFuture(commands.zremrangebyscore(key, range), span);
   }
 
   @Override
@@ -1629,7 +1630,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrevrange", key);
     span.setTag("start", start);
     span.setTag("stop", stop);
-    return setCompleteAction(commands.zrevrange(key, start, stop), span);
+    return prepareRedisFuture(commands.zrevrange(key, start, stop), span);
   }
 
   @Override
@@ -1638,7 +1639,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrevrange", key);
     span.setTag("start", start);
     span.setTag("stop", stop);
-    return setCompleteAction(commands.zrevrange(channel, key, start, stop), span);
+    return prepareRedisFuture(commands.zrevrange(channel, key, start, stop), span);
   }
 
   @Override
@@ -1647,7 +1648,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrevrangeWithScores", key);
     span.setTag("start", start);
     span.setTag("stop", stop);
-    return setCompleteAction(commands.zrevrangeWithScores(key, start, stop), span);
+    return prepareRedisFuture(commands.zrevrangeWithScores(key, start, stop), span);
   }
 
   @Override
@@ -1656,7 +1657,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrevrangeWithScores", key);
     span.setTag("start", start);
     span.setTag("stop", stop);
-    return setCompleteAction(commands.zrevrangeWithScores(channel, key, start, stop), span);
+    return prepareRedisFuture(commands.zrevrangeWithScores(channel, key, start, stop), span);
   }
 
   @Override
@@ -1664,7 +1665,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
       Range<? extends V> range) {
     Span span = helper.buildSpan("zrevrangebylex", key);
     span.setTag("range", nullable(range));
-    return setCompleteAction(commands.zrevrangebylex(key, range), span);
+    return prepareRedisFuture(commands.zrevrangebylex(key, range), span);
   }
 
   @Override
@@ -1673,7 +1674,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrevrangebylex", key);
     span.setTag("range", nullable(range));
     span.setTag("limit", nullable(limit));
-    return setCompleteAction(commands.zrevrangebylex(key, range, limit), span);
+    return prepareRedisFuture(commands.zrevrangebylex(key, range, limit), span);
   }
 
   @Override
@@ -1683,7 +1684,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrevrangebyscore", key);
     span.setTag("max", max);
     span.setTag("min", min);
-    return setCompleteAction(commands.zrevrangebyscore(key, max, min), span);
+    return prepareRedisFuture(commands.zrevrangebyscore(key, max, min), span);
   }
 
   @Override
@@ -1693,7 +1694,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrevrangebyscore", key);
     span.setTag("max", max);
     span.setTag("min", min);
-    return setCompleteAction(commands.zrevrangebyscore(key, max, min), span);
+    return prepareRedisFuture(commands.zrevrangebyscore(key, max, min), span);
   }
 
   @Override
@@ -1701,7 +1702,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
       Range<? extends Number> range) {
     Span span = helper.buildSpan("zrevrangebyscore", key);
     span.setTag("range", nullable(range));
-    return setCompleteAction(commands.zrevrangebyscore(key, range), span);
+    return prepareRedisFuture(commands.zrevrangebyscore(key, range), span);
   }
 
   @Override
@@ -1713,7 +1714,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     span.setTag("min", min);
     span.setTag("offset", offset);
     span.setTag("count", count);
-    return setCompleteAction(commands.zrevrangebyscore(key, max, min, offset, count), span);
+    return prepareRedisFuture(commands.zrevrangebyscore(key, max, min, offset, count), span);
   }
 
   @Override
@@ -1725,7 +1726,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     span.setTag("min", min);
     span.setTag("offset", offset);
     span.setTag("count", count);
-    return setCompleteAction(commands.zrevrangebyscore(key, max, min, offset, count), span);
+    return prepareRedisFuture(commands.zrevrangebyscore(key, max, min, offset, count), span);
   }
 
   @Override
@@ -1734,7 +1735,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrevrangebyscore", key);
     span.setTag("range", nullable(range));
     span.setTag("limit", nullable(limit));
-    return setCompleteAction(commands.zrevrangebyscore(key, range, limit), span);
+    return prepareRedisFuture(commands.zrevrangebyscore(key, range, limit), span);
   }
 
   @Override
@@ -1744,7 +1745,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrevrangebyscore", key);
     span.setTag("max", max);
     span.setTag("min", min);
-    return setCompleteAction(commands.zrevrangebyscore(channel, key, max, min), span);
+    return prepareRedisFuture(commands.zrevrangebyscore(channel, key, max, min), span);
   }
 
   @Override
@@ -1755,7 +1756,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrevrangebyscore", key);
     span.setTag("max", max);
     span.setTag("min", min);
-    return setCompleteAction(commands.zrevrangebyscore(channel, key, max, min), span);
+    return prepareRedisFuture(commands.zrevrangebyscore(channel, key, max, min), span);
   }
 
   @Override
@@ -1764,7 +1765,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
       Range<? extends Number> range) {
     Span span = helper.buildSpan("zrevrangebyscore", key);
     span.setTag("range", nullable(range));
-    return setCompleteAction(commands.zrevrangebyscore(channel, key, range), span);
+    return prepareRedisFuture(commands.zrevrangebyscore(channel, key, range), span);
   }
 
   @Override
@@ -1777,7 +1778,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     span.setTag("min", min);
     span.setTag("offset", offset);
     span.setTag("count", count);
-    return setCompleteAction(commands.zrevrangebyscore(channel, key, max, min, offset, count),
+    return prepareRedisFuture(commands.zrevrangebyscore(channel, key, max, min, offset, count),
         span);
   }
 
@@ -1791,7 +1792,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     span.setTag("min", min);
     span.setTag("offset", offset);
     span.setTag("count", count);
-    return setCompleteAction(commands.zrevrangebyscore(channel, key, max, min, offset, count),
+    return prepareRedisFuture(commands.zrevrangebyscore(channel, key, max, min, offset, count),
         span);
   }
 
@@ -1802,7 +1803,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrevrangebyscore", key);
     span.setTag("range", nullable(range));
     span.setTag("limit", nullable(limit));
-    return setCompleteAction(commands.zrevrangebyscore(channel, key, range, limit), span);
+    return prepareRedisFuture(commands.zrevrangebyscore(channel, key, range, limit), span);
   }
 
   @Override
@@ -1812,7 +1813,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrevrangebyscoreWithScores", key);
     span.setTag("max", max);
     span.setTag("min", min);
-    return setCompleteAction(commands.zrevrangebyscoreWithScores(key, max, min), span);
+    return prepareRedisFuture(commands.zrevrangebyscoreWithScores(key, max, min), span);
   }
 
   @Override
@@ -1822,7 +1823,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrevrangebyscoreWithScores", key);
     span.setTag("max", max);
     span.setTag("min", min);
-    return setCompleteAction(commands.zrevrangebyscoreWithScores(key, max, min), span);
+    return prepareRedisFuture(commands.zrevrangebyscoreWithScores(key, max, min), span);
   }
 
   @Override
@@ -1830,7 +1831,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
       K key, Range<? extends Number> range) {
     Span span = helper.buildSpan("zrevrangebyscoreWithScores", key);
     span.setTag("range", nullable(range));
-    return setCompleteAction(commands.zrevrangebyscoreWithScores(key, range), span);
+    return prepareRedisFuture(commands.zrevrangebyscoreWithScores(key, range), span);
   }
 
   @Override
@@ -1842,7 +1843,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     span.setTag("min", min);
     span.setTag("offset", offset);
     span.setTag("count", count);
-    return setCompleteAction(commands.zrevrangebyscoreWithScores(key, max, min, offset, count),
+    return prepareRedisFuture(commands.zrevrangebyscoreWithScores(key, max, min, offset, count),
         span);
   }
 
@@ -1855,7 +1856,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     span.setTag("min", min);
     span.setTag("offset", offset);
     span.setTag("count", count);
-    return setCompleteAction(commands.zrevrangebyscoreWithScores(key, max, min, offset, count),
+    return prepareRedisFuture(commands.zrevrangebyscoreWithScores(key, max, min, offset, count),
         span);
   }
 
@@ -1865,7 +1866,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrevrangebyscoreWithScores", key);
     span.setTag("range", nullable(range));
     span.setTag("limit", nullable(limit));
-    return setCompleteAction(commands.zrevrangebyscoreWithScores(key, range, limit), span);
+    return prepareRedisFuture(commands.zrevrangebyscoreWithScores(key, range, limit), span);
   }
 
   @Override
@@ -1875,7 +1876,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrevrangebyscoreWithScores", key);
     span.setTag("max", max);
     span.setTag("min", min);
-    return setCompleteAction(commands.zrevrangebyscoreWithScores(channel, key, max, min), span);
+    return prepareRedisFuture(commands.zrevrangebyscoreWithScores(channel, key, max, min), span);
   }
 
   @Override
@@ -1886,7 +1887,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrevrangebyscoreWithScores", key);
     span.setTag("max", max);
     span.setTag("min", min);
-    return setCompleteAction(commands.zrevrangebyscoreWithScores(channel, key, max, min), span);
+    return prepareRedisFuture(commands.zrevrangebyscoreWithScores(channel, key, max, min), span);
   }
 
   @Override
@@ -1895,7 +1896,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
       Range<? extends Number> range) {
     Span span = helper.buildSpan("zrevrangebyscoreWithScores", key);
     span.setTag("range", nullable(range));
-    return setCompleteAction(commands.zrevrangebyscoreWithScores(channel, key, range), span);
+    return prepareRedisFuture(commands.zrevrangebyscoreWithScores(channel, key, range), span);
   }
 
   @Override
@@ -1908,7 +1909,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     span.setTag("min", min);
     span.setTag("offset", offset);
     span.setTag("count", count);
-    return setCompleteAction(
+    return prepareRedisFuture(
         commands.zrevrangebyscoreWithScores(channel, key, max, min, offset, count), span);
   }
 
@@ -1922,7 +1923,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     span.setTag("min", min);
     span.setTag("offset", offset);
     span.setTag("count", count);
-    return setCompleteAction(
+    return prepareRedisFuture(
         commands.zrevrangebyscoreWithScores(channel, key, max, min, offset, count), span);
   }
 
@@ -1933,47 +1934,47 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("zrevrangebyscoreWithScores", key);
     span.setTag("range", nullable(range));
     span.setTag("limit", nullable(limit));
-    return setCompleteAction(commands.zrevrangebyscoreWithScores(channel, key, range, limit), span);
+    return prepareRedisFuture(commands.zrevrangebyscoreWithScores(channel, key, range, limit), span);
   }
 
   @Override
   public RedisFuture<Long> zrevrank(K key, V member) {
     Span span = helper.buildSpan("zrevrank", key);
-    return setCompleteAction(commands.zrevrank(key, member), span);
+    return prepareRedisFuture(commands.zrevrank(key, member), span);
   }
 
   @Override
   public RedisFuture<ScoredValueScanCursor<V>> zscan(K key) {
     Span span = helper.buildSpan("zscan", key);
-    return setCompleteAction(commands.zscan(key), span);
+    return prepareRedisFuture(commands.zscan(key), span);
   }
 
   @Override
   public RedisFuture<ScoredValueScanCursor<V>> zscan(K key,
       ScanArgs scanArgs) {
     Span span = helper.buildSpan("zscan", key);
-    return setCompleteAction(commands.zscan(key, scanArgs), span);
+    return prepareRedisFuture(commands.zscan(key, scanArgs), span);
   }
 
   @Override
   public RedisFuture<ScoredValueScanCursor<V>> zscan(K key,
       ScanCursor scanCursor, ScanArgs scanArgs) {
     Span span = helper.buildSpan("zscan", key);
-    return setCompleteAction(commands.zscan(key, scanCursor, scanArgs), span);
+    return prepareRedisFuture(commands.zscan(key, scanCursor, scanArgs), span);
   }
 
   @Override
   public RedisFuture<ScoredValueScanCursor<V>> zscan(K key,
       ScanCursor scanCursor) {
     Span span = helper.buildSpan("zscan", key);
-    return setCompleteAction(commands.zscan(key, scanCursor), span);
+    return prepareRedisFuture(commands.zscan(key, scanCursor), span);
   }
 
   @Override
   public RedisFuture<StreamScanCursor> zscan(
       ScoredValueStreamingChannel<V> channel, K key) {
     Span span = helper.buildSpan("zscan", key);
-    return setCompleteAction(commands.zscan(channel, key), span);
+    return prepareRedisFuture(commands.zscan(channel, key), span);
   }
 
   @Override
@@ -1981,7 +1982,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
       ScoredValueStreamingChannel<V> channel, K key,
       ScanArgs scanArgs) {
     Span span = helper.buildSpan("zscan", key);
-    return setCompleteAction(commands.zscan(channel, key, scanArgs), span);
+    return prepareRedisFuture(commands.zscan(channel, key, scanArgs), span);
   }
 
   @Override
@@ -1989,7 +1990,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
       ScoredValueStreamingChannel<V> channel, K key,
       ScanCursor scanCursor, ScanArgs scanArgs) {
     Span span = helper.buildSpan("zscan", key);
-    return setCompleteAction(commands.zscan(channel, key, scanCursor, scanArgs), span);
+    return prepareRedisFuture(commands.zscan(channel, key, scanCursor, scanArgs), span);
   }
 
   @Override
@@ -1997,79 +1998,79 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
       ScoredValueStreamingChannel<V> channel, K key,
       ScanCursor scanCursor) {
     Span span = helper.buildSpan("zscan", key);
-    return setCompleteAction(commands.zscan(channel, key, scanCursor), span);
+    return prepareRedisFuture(commands.zscan(channel, key, scanCursor), span);
   }
 
   @Override
   public RedisFuture<Double> zscore(K key, V member) {
     Span span = helper.buildSpan("zscore", key);
-    return setCompleteAction(commands.zscore(key, member), span);
+    return prepareRedisFuture(commands.zscore(key, member), span);
   }
 
   @Override
   public RedisFuture<Long> zunionstore(K destination, K... keys) {
     Span span = helper.buildSpan("zunionstore", keys);
-    return setCompleteAction(commands.zunionstore(destination, keys), span);
+    return prepareRedisFuture(commands.zunionstore(destination, keys), span);
   }
 
   @Override
   public RedisFuture<Long> zunionstore(K destination,
       ZStoreArgs storeArgs, K... keys) {
     Span span = helper.buildSpan("zunionstore", keys);
-    return setCompleteAction(commands.zunionstore(destination, storeArgs, keys), span);
+    return prepareRedisFuture(commands.zunionstore(destination, storeArgs, keys), span);
   }
 
   @Override
   public <T> RedisFuture<T> eval(String script, ScriptOutputType type,
       K... keys) {
     Span span = helper.buildSpan("eval", keys);
-    return setCompleteAction(commands.eval(script, type, keys), span);
+    return prepareRedisFuture(commands.eval(script, type, keys), span);
   }
 
   @Override
   public <T> RedisFuture<T> eval(String script, ScriptOutputType type,
       K[] keys, V... values) {
     Span span = helper.buildSpan("eval", keys);
-    return setCompleteAction(commands.eval(script, type, keys, values), span);
+    return prepareRedisFuture(commands.eval(script, type, keys, values), span);
   }
 
   @Override
   public <T> RedisFuture<T> evalsha(String digest,
       ScriptOutputType type, K... keys) {
     Span span = helper.buildSpan("evalsha", keys);
-    return setCompleteAction(commands.evalsha(digest, type, keys), span);
+    return prepareRedisFuture(commands.evalsha(digest, type, keys), span);
   }
 
   @Override
   public <T> RedisFuture<T> evalsha(String digest,
       ScriptOutputType type, K[] keys, V... values) {
     Span span = helper.buildSpan("evalsha", keys);
-    return setCompleteAction(commands.evalsha(digest, type, keys, values), span);
+    return prepareRedisFuture(commands.evalsha(digest, type, keys, values), span);
   }
 
   @Override
   public RedisFuture<List<Boolean>> scriptExists(
       String... digests) {
     Span span = helper.buildSpan("scriptExists");
-    return setCompleteAction(commands.scriptExists(digests), span);
+    return prepareRedisFuture(commands.scriptExists(digests), span);
   }
 
   @Override
   public RedisFuture<String> scriptFlush() {
     Span span = helper.buildSpan("scriptFlush");
-    return setCompleteAction(commands.scriptFlush(), span);
+    return prepareRedisFuture(commands.scriptFlush(), span);
   }
 
   @Override
   public RedisFuture<String> scriptKill() {
     Span span = helper.buildSpan("scriptKill");
-    return setCompleteAction(commands.scriptKill(), span);
+    return prepareRedisFuture(commands.scriptKill(), span);
   }
 
   @Override
   public RedisFuture<String> scriptLoad(V script) {
     Span span = helper.buildSpan("scriptLoad");
-    return setCompleteAction(commands.scriptLoad(script), span);
+    return prepareRedisFuture(commands.scriptLoad(script), span);
   }
 
   @Override
@@ -2088,55 +2089,55 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
   @Override
   public RedisFuture<String> bgrewriteaof() {
     Span span = helper.buildSpan("bgrewriteaof");
-    return setCompleteAction(commands.bgrewriteaof(), span);
+    return prepareRedisFuture(commands.bgrewriteaof(), span);
   }
 
   @Override
   public RedisFuture<String> bgsave() {
     Span span = helper.buildSpan("bgsave");
-    return setCompleteAction(commands.bgsave(), span);
+    return prepareRedisFuture(commands.bgsave(), span);
   }
 
   @Override
   public RedisFuture<K> clientGetname() {
     Span span = helper.buildSpan("clientGetname");
-    return setCompleteAction(commands.clientGetname(), span);
+    return prepareRedisFuture(commands.clientGetname(), span);
   }
 
   @Override
   public RedisFuture<String> clientSetname(K name) {
     Span span = helper.buildSpan("clientSetname");
-    return setCompleteAction(commands.clientSetname(name), span);
+    return prepareRedisFuture(commands.clientSetname(name), span);
   }
 
   @Override
   public RedisFuture<String> clientKill(String addr) {
     Span span = helper.buildSpan("clientKill");
-    return setCompleteAction(commands.clientKill(addr), span);
+    return prepareRedisFuture(commands.clientKill(addr), span);
   }
 
   @Override
   public RedisFuture<Long> clientKill(KillArgs killArgs) {
     Span span = helper.buildSpan("clientKill");
-    return setCompleteAction(commands.clientKill(killArgs), span);
+    return prepareRedisFuture(commands.clientKill(killArgs), span);
   }
 
   @Override
   public RedisFuture<String> clientPause(long timeout) {
     Span span = helper.buildSpan("clientPause");
-    return setCompleteAction(commands.clientPause(timeout), span);
+    return prepareRedisFuture(commands.clientPause(timeout), span);
   }
 
   @Override
   public RedisFuture<String> clientList() {
     Span span = helper.buildSpan("clientList");
-    return setCompleteAction(commands.clientList(), span);
+    return prepareRedisFuture(commands.clientList(), span);
   }
 
   @Override
   public RedisFuture<List<Object>> command() {
     Span span = helper.buildSpan("command");
-    return setCompleteAction(commands.command(), span);
+    return prepareRedisFuture(commands.command(), span);
   }
 
   @Override
@@ -2155,56 +2156,56 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
   @Override
   public RedisFuture<Long> commandCount() {
     Span span = helper.buildSpan("commandCount");
-    return setCompleteAction(commands.commandCount(), span);
+    return prepareRedisFuture(commands.commandCount(), span);
   }
 
   @Override
   public RedisFuture<Map<String, String>> configGet(
       String parameter) {
     Span span = helper.buildSpan("configGet");
-    return setCompleteAction(commands.configGet(parameter), span);
+    return prepareRedisFuture(commands.configGet(parameter), span);
   }
 
   @Override
   public RedisFuture<String> configResetstat() {
     Span span = helper.buildSpan("configResetstat");
-    return setCompleteAction(commands.configResetstat(), span);
+    return prepareRedisFuture(commands.configResetstat(), span);
   }
 
   @Override
   public RedisFuture<String> configRewrite() {
     Span span = helper.buildSpan("configRewrite");
-    return setCompleteAction(commands.configRewrite(), span);
+    return prepareRedisFuture(commands.configRewrite(), span);
   }
 
   @Override
   public RedisFuture<String> configSet(String parameter, String value) {
     Span span = helper.buildSpan("configSet");
-    return setCompleteAction(commands.configSet(parameter, value), span);
+    return prepareRedisFuture(commands.configSet(parameter, value), span);
   }
 
   @Override
   public RedisFuture<Long> dbsize() {
     Span span = helper.buildSpan("dbsize");
-    return setCompleteAction(commands.dbsize(), span);
+    return prepareRedisFuture(commands.dbsize(), span);
   }
 
   @Override
   public RedisFuture<String> debugCrashAndRecover(Long delay) {
     Span span = helper.buildSpan("debugCrashAndRecover");
-    return setCompleteAction(commands.debugCrashAndRecover(delay), span);
+    return prepareRedisFuture(commands.debugCrashAndRecover(delay), span);
   }
 
   @Override
   public RedisFuture<String> debugHtstats(int db) {
     Span span = helper.buildSpan("debugHtstats");
-    return setCompleteAction(commands.debugHtstats(db), span);
+    return prepareRedisFuture(commands.debugHtstats(db), span);
   }
 
   @Override
   public RedisFuture<String> debugObject(K key) {
     Span span = helper.buildSpan("debugObject", key);
-    return setCompleteAction(commands.debugObject(key), span);
+    return prepareRedisFuture(commands.debugObject(key), span);
   }
 
   @Override
@@ -2236,67 +2237,67 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
   @Override
   public RedisFuture<String> debugReload() {
     Span span = helper.buildSpan("debugReload");
-    return setCompleteAction(commands.debugReload(), span);
+    return prepareRedisFuture(commands.debugReload(), span);
   }
 
   @Override
   public RedisFuture<String> debugRestart(Long delay) {
     Span span = helper.buildSpan("debugRestart");
-    return setCompleteAction(commands.debugRestart(delay), span);
+    return prepareRedisFuture(commands.debugRestart(delay), span);
   }
 
   @Override
   public RedisFuture<String> debugSdslen(K key) {
     Span span = helper.buildSpan("debugSdslen", key);
-    return setCompleteAction(commands.debugSdslen(key), span);
+    return prepareRedisFuture(commands.debugSdslen(key), span);
   }
 
   @Override
   public RedisFuture<String> flushall() {
     Span span = helper.buildSpan("flushall");
-    return setCompleteAction(commands.flushall(), span);
+    return prepareRedisFuture(commands.flushall(), span);
   }
 
   @Override
   public RedisFuture<String> flushallAsync() {
     Span span = helper.buildSpan("flushallAsync");
-    return setCompleteAction(commands.flushallAsync(), span);
+    return prepareRedisFuture(commands.flushallAsync(), span);
   }
 
   @Override
   public RedisFuture<String> flushdb() {
     Span span = helper.buildSpan("flushdb");
-    return setCompleteAction(commands.flushdb(), span);
+    return prepareRedisFuture(commands.flushdb(), span);
   }
 
   @Override
   public RedisFuture<String> flushdbAsync() {
     Span span = helper.buildSpan("flushdbAsync");
-    return setCompleteAction(commands.flushdbAsync(), span);
+    return prepareRedisFuture(commands.flushdbAsync(), span);
   }
 
   @Override
   public RedisFuture<String> info() {
     Span span = helper.buildSpan("info");
-    return setCompleteAction(commands.info(), span);
+    return prepareRedisFuture(commands.info(), span);
   }
 
   @Override
   public RedisFuture<String> info(String section) {
     Span span = helper.buildSpan("info");
-    return setCompleteAction(commands.info(section), span);
+    return prepareRedisFuture(commands.info(section), span);
   }
 
   @Override
   public RedisFuture<Date> lastsave() {
     Span span = helper.buildSpan("lastsave");
-    return setCompleteAction(commands.lastsave(), span);
+    return prepareRedisFuture(commands.lastsave(), span);
   }
 
   @Override
   public RedisFuture<String> save() {
     Span span = helper.buildSpan("save");
-    return setCompleteAction(commands.save(), span);
+    return prepareRedisFuture(commands.save(), span);
   }
 
   @Override
@@ -2315,140 +2316,140 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
   @Override
   public RedisFuture<String> slaveof(String host, int port) {
     Span span = helper.buildSpan("slaveof");
-    return setCompleteAction(commands.slaveof(host, port), span);
+    return prepareRedisFuture(commands.slaveof(host, port), span);
   }
 
   @Override
   public RedisFuture<String> slaveofNoOne() {
     Span span = helper.buildSpan("slaveofNoOne");
-    return setCompleteAction(commands.slaveofNoOne(), span);
+    return prepareRedisFuture(commands.slaveofNoOne(), span);
   }
 
   @Override
   public RedisFuture<List<Object>> slowlogGet() {
     Span span = helper.buildSpan("slowlogGet");
-    return setCompleteAction(commands.slowlogGet(), span);
+    return prepareRedisFuture(commands.slowlogGet(), span);
   }
 
   @Override
   public RedisFuture<List<Object>> slowlogGet(int count) {
     Span span = helper.buildSpan("slowlogGet");
-    return setCompleteAction(commands.slowlogGet(count), span);
+    return prepareRedisFuture(commands.slowlogGet(count), span);
   }
 
   @Override
   public RedisFuture<Long> slowlogLen() {
     Span span = helper.buildSpan("slowlogLen");
-    return setCompleteAction(commands.slowlogLen(), span);
+    return prepareRedisFuture(commands.slowlogLen(), span);
   }
 
   @Override
   public RedisFuture<String> slowlogReset() {
     Span span = helper.buildSpan("slowlogReset");
-    return setCompleteAction(commands.slowlogReset(), span);
+    return prepareRedisFuture(commands.slowlogReset(), span);
   }
 
   @Override
   public RedisFuture<List<V>> time() {
     Span span = helper.buildSpan("time");
-    return setCompleteAction(commands.time(), span);
+    return prepareRedisFuture(commands.time(), span);
   }
 
   @Override
   public RedisFuture<Long> pfadd(K key, V... values) {
     Span span = helper.buildSpan("pfadd", key);
-    return setCompleteAction(commands.pfadd(key, values), span);
+    return prepareRedisFuture(commands.pfadd(key, values), span);
   }
 
   @Override
   public RedisFuture<String> pfmerge(K destkey, K... sourcekeys) {
     Span span = helper.buildSpan("pfmerge");
-    return setCompleteAction(commands.pfmerge(destkey, sourcekeys), span);
+    return prepareRedisFuture(commands.pfmerge(destkey, sourcekeys), span);
   }
 
   @Override
   public RedisFuture<Long> pfcount(K... keys) {
     Span span = helper.buildSpan("pfcount", keys);
-    return setCompleteAction(commands.pfcount(keys), span);
+    return prepareRedisFuture(commands.pfcount(keys), span);
   }
 
   @Override
   public RedisFuture<Long> publish(K channel, V message) {
     Span span = helper.buildSpan("publish");
-    return setCompleteAction(commands.publish(channel, message), span);
+    return prepareRedisFuture(commands.publish(channel, message), span);
   }
 
   @Override
   public RedisFuture<List<K>> pubsubChannels() {
     Span span = helper.buildSpan("pubsubChannels");
-    return setCompleteAction(commands.pubsubChannels(), span);
+    return prepareRedisFuture(commands.pubsubChannels(), span);
   }
 
   @Override
   public RedisFuture<List<K>> pubsubChannels(K channel) {
     Span span = helper.buildSpan("pubsubChannels");
-    return setCompleteAction(commands.pubsubChannels(channel), span);
+    return prepareRedisFuture(commands.pubsubChannels(channel), span);
   }
 
   @Override
   public RedisFuture<Map<K, Long>> pubsubNumsub(K... channels) {
     Span span = helper.buildSpan("pubsubNumsub");
-    return setCompleteAction(commands.pubsubNumsub(channels), span);
+    return prepareRedisFuture(commands.pubsubNumsub(channels), span);
   }
 
   @Override
   public RedisFuture<Long> pubsubNumpat() {
     Span span = helper.buildSpan("pubsubNumpat");
-    return setCompleteAction(commands.pubsubNumpat(), span);
+    return prepareRedisFuture(commands.pubsubNumpat(), span);
   }
 
   @Override
   public RedisFuture<V> echo(V msg) {
     Span span = helper.buildSpan("echo");
-    return setCompleteAction(commands.echo(msg), span);
+    return prepareRedisFuture(commands.echo(msg), span);
   }
 
   @Override
   public RedisFuture<List<Object>> role() {
     Span span = helper.buildSpan("role");
-    return setCompleteAction(commands.role(), span);
+    return prepareRedisFuture(commands.role(), span);
   }
 
   @Override
   public RedisFuture<String> ping() {
     Span span = helper.buildSpan("ping");
-    return setCompleteAction(commands.ping(), span);
+    return prepareRedisFuture(commands.ping(), span);
   }
 
   @Override
   public RedisFuture<String> readOnly() {
     Span span = helper.buildSpan("readOnly");
-    return setCompleteAction(commands.readOnly(), span);
+    return prepareRedisFuture(commands.readOnly(), span);
   }
 
   @Override
   public RedisFuture<String> readWrite() {
     Span span = helper.buildSpan("readWrite");
-    return setCompleteAction(commands.readWrite(), span);
+    return prepareRedisFuture(commands.readWrite(), span);
   }
 
   @Override
   public RedisFuture<String> quit() {
     Span span = helper.buildSpan("quit");
-    return setCompleteAction(commands.quit(), span);
+    return prepareRedisFuture(commands.quit(), span);
   }
 
   @Override
   public RedisFuture<Long> waitForReplication(int replicas, long timeout) {
     Span span = helper.buildSpan("waitForReplication");
-    return setCompleteAction(commands.waitForReplication(replicas, timeout), span);
+    return prepareRedisFuture(commands.waitForReplication(replicas, timeout), span);
   }
 
   @Override
   public <T> RedisFuture<T> dispatch(ProtocolKeyword type,
       CommandOutput<K, V, T> output) {
     Span span = helper.buildSpan("dispatch");
-    return setCompleteAction(commands.dispatch(type, output), span);
+    return prepareRedisFuture(commands.dispatch(type, output), span);
   }
 
   @Override
@@ -2456,7 +2457,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
       CommandOutput<K, V, T> output,
       CommandArgs<K, V> args) {
     Span span = helper.buildSpan("dispatch");
-    return setCompleteAction(commands.dispatch(type, output, args), span);
+    return prepareRedisFuture(commands.dispatch(type, output, args), span);
   }
 
   @Override
@@ -2543,34 +2544,34 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
   @Override
   public RedisFuture<String> clusterBumpepoch() {
     Span span = helper.buildSpan("clusterBumpepoch");
-    return setCompleteAction(commands.clusterBumpepoch(), span);
+    return prepareRedisFuture(commands.clusterBumpepoch(), span);
   }
 
   @Override
   public RedisFuture<String> clusterMeet(String ip, int port) {
     Span span = helper.buildSpan("clusterMeet");
-    return setCompleteAction(commands.clusterMeet(ip, port), span);
+    return prepareRedisFuture(commands.clusterMeet(ip, port), span);
   }
 
   @Override
   public RedisFuture<String> clusterForget(String nodeId) {
     Span span = helper.buildSpan("clusterForget");
     span.setTag("nodeId", nodeId);
-    return setCompleteAction(commands.clusterForget(nodeId), span);
+    return prepareRedisFuture(commands.clusterForget(nodeId), span);
   }
 
   @Override
   public RedisFuture<String> clusterAddSlots(int... slots) {
     Span span = helper.buildSpan("clusterAddSlots");
     span.setTag("slots", Arrays.toString(slots));
-    return setCompleteAction(commands.clusterAddSlots(slots), span);
+    return prepareRedisFuture(commands.clusterAddSlots(slots), span);
   }
 
   @Override
   public RedisFuture<String> clusterDelSlots(int... slots) {
     Span span = helper.buildSpan("clusterDelSlots");
     span.setTag("slots", Arrays.toString(slots));
-    return setCompleteAction(commands.clusterDelSlots(slots), span);
+    return prepareRedisFuture(commands.clusterDelSlots(slots), span);
   }
 
   @Override
@@ -2578,14 +2579,14 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("clusterSetSlotNode");
     span.setTag("slot", slot);
     span.setTag("nodeId", nodeId);
-    return setCompleteAction(commands.clusterSetSlotNode(slot, nodeId), span);
+    return prepareRedisFuture(commands.clusterSetSlotNode(slot, nodeId), span);
   }
 
   @Override
   public RedisFuture<String> clusterSetSlotStable(int slot) {
     Span span = helper.buildSpan("clusterSetSlotStable");
     span.setTag("slot", slot);
-    return setCompleteAction(commands.clusterSetSlotStable(slot), span);
+    return prepareRedisFuture(commands.clusterSetSlotStable(slot), span);
   }
 
   @Override
@@ -2594,7 +2595,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("clusterSetSlotMigrating");
     span.setTag("slot", slot);
     span.setTag("nodeId", nodeId);
-    return setCompleteAction(commands.clusterSetSlotMigrating(slot, nodeId), span);
+    return prepareRedisFuture(commands.clusterSetSlotMigrating(slot, nodeId), span);
   }
 
   @Override
@@ -2603,110 +2604,110 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("clusterSetSlotImporting");
     span.setTag("slot", slot);
     span.setTag("nodeId", nodeId);
-    return setCompleteAction(commands.clusterSetSlotImporting(slot, nodeId), span);
+    return prepareRedisFuture(commands.clusterSetSlotImporting(slot, nodeId), span);
   }
 
   @Override
   public RedisFuture<String> clusterInfo() {
     Span span = helper.buildSpan("clusterInfo");
-    return setCompleteAction(commands.clusterInfo(), span);
+    return prepareRedisFuture(commands.clusterInfo(), span);
   }
 
   @Override
   public RedisFuture<String> clusterMyId() {
     Span span = helper.buildSpan("clusterMyId");
-    return setCompleteAction(commands.clusterMyId(), span);
+    return prepareRedisFuture(commands.clusterMyId(), span);
   }
 
   @Override
   public RedisFuture<String> clusterNodes() {
     Span span = helper.buildSpan("clusterNodes");
-    return setCompleteAction(commands.clusterNodes(), span);
+    return prepareRedisFuture(commands.clusterNodes(), span);
   }
 
   @Override
   public RedisFuture<List<String>> clusterSlaves(String nodeId) {
     Span span = helper.buildSpan("clusterSlaves");
     span.setTag("nodeId", nodeId);
-    return setCompleteAction(commands.clusterSlaves(nodeId), span);
+    return prepareRedisFuture(commands.clusterSlaves(nodeId), span);
   }
 
   @Override
   public RedisFuture<List<K>> clusterGetKeysInSlot(int slot, int count) {
     Span span = helper.buildSpan("clusterGetKeysInSlot");
     span.setTag("slot", slot);
-    return setCompleteAction(commands.clusterGetKeysInSlot(slot, count), span);
+    return prepareRedisFuture(commands.clusterGetKeysInSlot(slot, count), span);
   }
 
   @Override
   public RedisFuture<Long> clusterCountKeysInSlot(int slot) {
     Span span = helper.buildSpan("clusterCountKeysInSlot");
     span.setTag("slot", slot);
-    return setCompleteAction(commands.clusterCountKeysInSlot(slot), span);
+    return prepareRedisFuture(commands.clusterCountKeysInSlot(slot), span);
   }
 
   @Override
   public RedisFuture<Long> clusterCountFailureReports(String nodeId) {
     Span span = helper.buildSpan("clusterCountFailureReports");
     span.setTag("nodeId", nodeId);
-    return setCompleteAction(commands.clusterCountFailureReports(nodeId), span);
+    return prepareRedisFuture(commands.clusterCountFailureReports(nodeId), span);
   }
 
   @Override
   public RedisFuture<Long> clusterKeyslot(K key) {
     Span span = helper.buildSpan("clusterKeyslot", key);
-    return setCompleteAction(commands.clusterKeyslot(key), span);
+    return prepareRedisFuture(commands.clusterKeyslot(key), span);
   }
 
   @Override
   public RedisFuture<String> clusterSaveconfig() {
     Span span = helper.buildSpan("clusterSaveconfig");
-    return setCompleteAction(commands.clusterSaveconfig(), span);
+    return prepareRedisFuture(commands.clusterSaveconfig(), span);
   }
 
   @Override
   public RedisFuture<String> clusterSetConfigEpoch(long configEpoch) {
     Span span = helper.buildSpan("clusterSetConfigEpoch");
-    return setCompleteAction(commands.clusterSetConfigEpoch(configEpoch), span);
+    return prepareRedisFuture(commands.clusterSetConfigEpoch(configEpoch), span);
   }
 
   @Override
   public RedisFuture<List<Object>> clusterSlots() {
     Span span = helper.buildSpan("clusterSlots");
-    return setCompleteAction(commands.clusterSlots(), span);
+    return prepareRedisFuture(commands.clusterSlots(), span);
   }
 
   @Override
   public RedisFuture<String> asking() {
     Span span = helper.buildSpan("asking");
-    return setCompleteAction(commands.asking(), span);
+    return prepareRedisFuture(commands.asking(), span);
   }
 
   @Override
   public RedisFuture<String> clusterReplicate(String nodeId) {
     Span span = helper.buildSpan("clusterReplicate");
     span.setTag("nodeId", nodeId);
-    return setCompleteAction(commands.clusterReplicate(nodeId), span);
+    return prepareRedisFuture(commands.clusterReplicate(nodeId), span);
   }
 
   @Override
   public RedisFuture<String> clusterFailover(boolean force) {
     Span span = helper.buildSpan("clusterFailover");
     span.setTag("force", force);
-    return setCompleteAction(commands.clusterFailover(force), span);
+    return prepareRedisFuture(commands.clusterFailover(force), span);
   }
 
   @Override
   public RedisFuture<String> clusterReset(boolean hard) {
     Span span = helper.buildSpan("clusterReset");
     span.setTag("hard", hard);
-    return setCompleteAction(commands.clusterReset(hard), span);
+    return prepareRedisFuture(commands.clusterReset(hard), span);
   }
 
   @Override
   public RedisFuture<String> clusterFlushslots() {
     Span span = helper.buildSpan("clusterFlushslots");
-    return setCompleteAction(commands.clusterFlushslots(), span);
+    return prepareRedisFuture(commands.clusterFlushslots(), span);
   }
 
   @Override
@@ -2714,20 +2715,20 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("geoadd", key);
     span.setTag("longitude", longitude);
     span.setTag("latitude", latitude);
-    return setCompleteAction(commands.geoadd(key, longitude, latitude, member), span);
+    return prepareRedisFuture(commands.geoadd(key, longitude, latitude, member), span);
   }
 
   @Override
   public RedisFuture<Long> geoadd(K key, Object... lngLatMember) {
     Span span = helper.buildSpan("geoadd", key);
-    return setCompleteAction(commands.geoadd(key, lngLatMember), span);
+    return prepareRedisFuture(commands.geoadd(key, lngLatMember), span);
   }
 
   @Override
   public RedisFuture<List<Value<String>>> geohash(K key,
       V... members) {
     Span span = helper.buildSpan("geohash", key);
-    return setCompleteAction(commands.geohash(key, members), span);
+    return prepareRedisFuture(commands.geohash(key, members), span);
   }
 
   @Override
@@ -2738,7 +2739,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     span.setTag("latitude", latitude);
     span.setTag("unit", nullable(unit));
     span.setTag("distance", distance);
-    return setCompleteAction(commands.georadius(key, longitude, latitude, distance, unit), span);
+    return prepareRedisFuture(commands.georadius(key, longitude, latitude, distance, unit), span);
   }
 
   @Override
@@ -2750,7 +2751,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     span.setTag("latitude", latitude);
     span.setTag("unit", nullable(unit));
     span.setTag("distance", distance);
-    return setCompleteAction(commands.georadius(key, longitude, latitude, distance, unit, geoArgs),
+    return prepareRedisFuture(commands.georadius(key, longitude, latitude, distance, unit, geoArgs),
         span);
   }
 
@@ -2763,7 +2764,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     span.setTag("latitude", latitude);
     span.setTag("unit", nullable(unit));
     span.setTag("distance", distance);
-    return setCompleteAction(
+    return prepareRedisFuture(
         commands.georadius(key, longitude, latitude, distance, unit, geoRadiusStoreArgs), span);
   }
 
@@ -2773,7 +2774,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("georadiusbymember", key);
     span.setTag("unit", nullable(unit));
     span.setTag("distance", distance);
-    return setCompleteAction(commands.georadiusbymember(key, member, distance, unit), span);
+    return prepareRedisFuture(commands.georadiusbymember(key, member, distance, unit), span);
   }
 
   @Override
@@ -2783,7 +2784,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("georadiusbymember", key);
     span.setTag("unit", nullable(unit));
     span.setTag("distance", distance);
-    return setCompleteAction(commands.georadiusbymember(key, member, distance, unit, geoArgs),
+    return prepareRedisFuture(commands.georadiusbymember(key, member, distance, unit, geoArgs),
         span);
   }
 
@@ -2793,7 +2794,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
     Span span = helper.buildSpan("georadiusbymember", key);
     span.setTag("unit", nullable(unit));
     span.setTag("distance", distance);
-    return setCompleteAction(
+    return prepareRedisFuture(
         commands.georadiusbymember(key, member, distance, unit, geoRadiusStoreArgs), span);
   }
 
@@ -2801,7 +2802,7 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
   public RedisFuture<List<GeoCoordinates>> geopos(K key,
       V... members) {
     Span span = helper.buildSpan("geopos", key);
-    return setCompleteAction(commands.geopos(key, members), span);
+    return prepareRedisFuture(commands.geopos(key, members), span);
   }
 
   @Override
@@ -2809,40 +2810,44 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
       Unit unit) {
     Span span = helper.buildSpan("geodist", key);
     span.setTag("unit", nullable(unit));
-    return setCompleteAction(commands.geodist(key, from, to, unit), span);
+    return prepareRedisFuture(commands.geodist(key, from, to, unit), span);
   }
 
   @Override
   public RedisFuture<String> discard() {
     Span span = helper.buildSpan("discard");
-    return setCompleteAction(commands.discard(), span);
+    return prepareRedisFuture(commands.discard(), span);
   }
 
   @Override
   public RedisFuture<TransactionResult> exec() {
     Span span = helper.buildSpan("exec");
-    return setCompleteAction(commands.exec(), span);
+    return prepareRedisFuture(commands.exec(), span);
   }
 
   @Override
   public RedisFuture<String> multi() {
     Span span = helper.buildSpan("multi");
-    return setCompleteAction(commands.multi(), span);
+    return prepareRedisFuture(commands.multi(), span);
   }
 
   @Override
   public RedisFuture<String> watch(K... keys) {
     Span span = helper.buildSpan("watch", keys);
-    return setCompleteAction(commands.watch(keys), span);
+    return prepareRedisFuture(commands.watch(keys), span);
   }
 
   @Override
   public RedisFuture<String> unwatch() {
     Span span = helper.buildSpan("unwatch");
-    return setCompleteAction(commands.unwatch(), span);
+    return prepareRedisFuture(commands.unwatch(), span);
   }
 
-  static <V> RedisFuture<V> setCompleteAction(RedisFuture<V> future, Span span) {
+  protected <V> RedisFuture<V> prepareRedisFuture(RedisFuture<V> future, Span span) {
+    return continueScopeSpan(setCompleteAction(future,span));
+  }
+
+  protected <V> RedisFuture<V> setCompleteAction(RedisFuture<V> future, Span span) {
     future.whenComplete((v, throwable) -> {
       if (throwable != null) {
         onError(throwable, span);
@@ -2852,4 +2857,20 @@ public class TracingRedisAsyncCommands<K, V> implements RedisAsyncCommands<K, V>
 
     return future;
   }
+
+  protected <T> RedisFuture<T> continueScopeSpan(RedisFuture<T> redisFuture){
+    Span span = tracer.activeSpan();
+    CompletableRedisFuture<T> customRedisFuture = new CompletableRedisFuture<>(redisFuture);
+    redisFuture.whenComplete((v, throwable) -> {
+      try (Scope ignored = tracer.scopeManager().activate(span,false)) {
+        if (throwable != null) {
+          customRedisFuture.completeExceptionally(throwable);
+        } else {
+          customRedisFuture.complete(v);
+        }
+      }
+    });
+    return customRedisFuture;
+  }
+
 }


### PR DESCRIPTION
Hi guys!

I use opentracing spring boot on my project with many futures and completationStages and I notice that some of my spans wasn't attach to my trace when I use lettuce async operations. I found that when I make some "thenApply", "thenCompose" on RedisFuture, the tracer lost the current scope and span.