### PR TITLE
Support for TracingConfiguration with opentracing-redis-redisson

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,9 +179,6 @@ RedisAsyncCommands<String, String> commandsAsync = connection.async();
 ### Redisson
 
 ```java
-// Instantiate tracer
-Tracer tracer = ...
-
 // Create Redisson config object
 Config = ...
 
@@ -189,7 +186,7 @@ Config = ...
 RedissonClient redissonClient = Redisson.create(config);
 
 // Decorate RedissonClient with TracingRedissonClient
-RedissonClient tracingRedissonClient =  new TracingRedissonClient(redissonClient, tracer);
+RedissonClient tracingRedissonClient =  new TracingRedissonClient(redissonClient, tracingConfiguration);
 
 // Get object you need using TracingRedissonClient
 RMap<MyKey, MyValue> map = tracingRedissonClient.getMap("myMap");

--- a/opentracing-redis-redisson/src/main/java/io/opentracing/contrib/redis/redisson/TracingRedissonClient.java
+++ b/opentracing-redis-redisson/src/main/java/io/opentracing/contrib/redis/redisson/TracingRedissonClient.java
@@ -90,6 +90,11 @@ public class TracingRedissonClient implements RedissonClient {
             .build());
   }
 
+  public TracingRedissonClient(RedissonClient redissonClient, TracingConfiguration configuration) {
+    this.redissonClient = redissonClient;
+    this.tracingRedissonHelper = new TracingRedissonHelper(configuration);
+  }
+
   @Override
   public <K, V> RStream<K, V> getStream(String name) {
     return redissonClient.getStream(name);


### PR DESCRIPTION
Adds support for TracingConfiguration when creating a new Redisson client. 