### PR TITLE
fix getReactiveConnection()

### DIFF
--- a/opentracing-redis-spring-data2/src/main/java/io/opentracing/contrib/redis/spring/data2/connection/TracingRedisConnectionFactory.java
+++ b/opentracing-redis-spring-data2/src/main/java/io/opentracing/contrib/redis/spring/data2/connection/TracingRedisConnectionFactory.java
@@ -72,7 +72,7 @@ public class TracingRedisConnectionFactory implements RedisConnectionFactory,
   @Override
   public ReactiveRedisConnection getReactiveConnection() {
     if (delegate instanceof ReactiveRedisConnectionFactory) {
-      return new TracingReactiveRedisConnection((ReactiveRedisConnection) delegate,
+      return new TracingReactiveRedisConnection(((ReactiveRedisConnectionFactory) delegate).getReactiveConnection(),
           tracingConfiguration);
     }
     // TODO: shouldn't we throw an exception?


### PR DESCRIPTION
RedisConnectionFactory cant castcannot be cask to ReactiveRedisConnection