### PR TITLE
Set scope=provided

### DIFF
--- a/opentracing-redis-jedis/pom.xml
+++ b/opentracing-redis-jedis/pom.xml
@@ -38,6 +38,7 @@
       <groupId>redis.clients</groupId>
       <artifactId>jedis</artifactId>
       <version>2.10.2</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/opentracing-redis-jedis3/pom.xml
+++ b/opentracing-redis-jedis3/pom.xml
@@ -38,6 +38,7 @@
       <groupId>redis.clients</groupId>
       <artifactId>jedis</artifactId>
       <version>3.1.0</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/opentracing-redis-lettuce/pom.xml
+++ b/opentracing-redis-lettuce/pom.xml
@@ -38,6 +38,7 @@
       <groupId>io.lettuce</groupId>
       <artifactId>lettuce-core</artifactId>
       <version>5.1.8.RELEASE</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/opentracing-redis-lettuce5.0/pom.xml
+++ b/opentracing-redis-lettuce5.0/pom.xml
@@ -38,6 +38,7 @@
       <groupId>io.lettuce</groupId>
       <artifactId>lettuce-core</artifactId>
       <version>5.0.5.RELEASE</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/opentracing-redis-redisson/pom.xml
+++ b/opentracing-redis-redisson/pom.xml
@@ -38,6 +38,7 @@
       <groupId>org.redisson</groupId>
       <artifactId>redisson</artifactId>
       <version>3.11.2</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/opentracing-redis-spring-data/pom.xml
+++ b/opentracing-redis-spring-data/pom.xml
@@ -43,7 +43,7 @@
       <groupId>org.springframework.data</groupId>
       <artifactId>spring-data-redis</artifactId>
       <version>${spring.data.redis.version}</version>
-      <optional>true</optional>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/opentracing-redis-spring-data2/pom.xml
+++ b/opentracing-redis-spring-data2/pom.xml
@@ -44,14 +44,14 @@
       <groupId>org.springframework.data</groupId>
       <artifactId>spring-data-redis</artifactId>
       <version>${spring.data.redis.version}</version>
-      <optional>true</optional>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>io.projectreactor</groupId>
       <artifactId>reactor-core</artifactId>
       <version>3.1.9.RELEASE</version>
-      <optional>true</optional>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Setting the scope of the target libraries of instrumentation to "provided". It is a guarantee that the integrating codebase will provide these libraries, otherwise the instrumentation plugin would be moot if the codebase does not already have these libraries.