### PR TITLE
Fixed issue with exists(keys), unlink, and touch

### DIFF
--- a/opentracing-redis-spring-data2/src/main/java/io/opentracing/contrib/redis/spring/data2/connection/TracingRedisConnection.java
+++ b/opentracing-redis-spring-data2/src/main/java/io/opentracing/contrib/redis/spring/data2/connection/TracingRedisConnection.java
@@ -185,7 +185,7 @@ public class TracingRedisConnection implements RedisConnection {
 
   @Override
   public Long exists(byte[]... keys) {
-    return helper.doInScope(RedisCommand.EXISTS, keys, connection::exists);
+    return helper.doInScope(RedisCommand.EXISTS, keys, () -> connection.exists(keys));
   }
 
   @Override
@@ -195,7 +195,7 @@ public class TracingRedisConnection implements RedisConnection {
 
   @Override
   public Long unlink(byte[]... keys) {
-    return helper.doInScope(RedisCommand.UNLINK, keys, connection::unlink);
+    return helper.doInScope(RedisCommand.UNLINK, keys, () -> connection.unlink(keys));
   }
 
   @Override
@@ -205,7 +205,7 @@ public class TracingRedisConnection implements RedisConnection {
 
   @Override
   public Long touch(byte[]... keys) {
-    return helper.doInScope(RedisCommand.TOUCH, keys, connection::touch);
+    return helper.doInScope(RedisCommand.TOUCH, keys, () -> connection.touch(keys));
   }
 
   @Override


### PR DESCRIPTION
Issue found with versions 0.1.2 through 0.1.15-SNAPSHOT of this class where the expected functionality of exists(keys), unlink(keys), and touch(keys) are not met. In early versions, no error would be found, and in newer versions, sometimes an error would be found if empty keys were not allowed.