### PR TITLE
Fix Redisson Async Tracing

### DIFF
--- a/opentracing-redis-redisson/src/main/java/io/opentracing/contrib/redis/redisson/TracingRedissonHelper.java
+++ b/opentracing-redis-redisson/src/main/java/io/opentracing/contrib/redis/redisson/TracingRedissonHelper.java
@@ -32,8 +32,7 @@ class TracingRedissonHelper extends TracingHelper {
   }
 
 
-  private <T> RFuture<T> continueScopeSpan(RFuture<T> redisFuture) {
-    Span span = tracer.activeSpan();
+  private <T> RFuture<T> continueScopeSpan(RFuture<T> redisFuture, Span span) {
     CompletableRFuture<T> customRedisFuture = new CompletableRFuture<>(redisFuture);
     redisFuture.whenComplete((v, throwable) -> {
       try (Scope ignored = tracer.scopeManager().activate(span)) {
@@ -68,6 +67,6 @@ class TracingRedissonHelper extends TracingHelper {
       throw e;
     }
 
-    return continueScopeSpan(setCompleteAction(future, span));
+    return continueScopeSpan(setCompleteAction(future, span), span);
   }
 }


### PR DESCRIPTION
Fixes the below scenario:

**Issue Reproduction Steps:**
1. Start with no active span
2. Run a Redis async call like "RedissonMap.getAsync().toCompletableFuture().get()"

**Expected:**
Spans are created and the call doesn't hang

**Actual:**
The get() function hangs

**Notes on fix**
I'm not 100% sure whether or not I should be activating the parent span or the built span in the continueScopeSpan function.  I'm not sure why we would want to activate an already activated span, but it's possible that's how this works.